### PR TITLE
[feat] utilize add-to-project action to auto-assign issues to project board

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,9 +1,9 @@
 ---
 name: Bug Report
 about: Something not working right? Let us know!
-title: '[Bug] <title>'
+title: '[bug] '
 labels: bug
-assignees: vchung
+assignees: 
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,9 +1,9 @@
 ---
 name: Feature Request
 about: Have an idea for a new feature? Please share 🤝
-title: '[Feature] <title>'
+title: '[feat] '
 labels: feature
-assignees: vchung
+assignees: 
 
 ---
 

--- a/.github/workflows/add-to-project.yml
+++ b/.github/workflows/add-to-project.yml
@@ -1,0 +1,18 @@
+name: Add bugs to bugs project
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@RELEASE_VERSION
+        with:
+          project-url: https://github.com/orgs/Sage-Bionetworks-Challenges/projects/1
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}
+          labeled: bug, feature
+          label-operator: OR


### PR DESCRIPTION
## Changelog
- add CI workflow for `add-to-project` action
- remove default assignee in issue templates
