### PR TITLE
only build when changes made to docs folder/mkdocs.yaml

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,6 +3,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**/*.md'
+      - 'docs/assets/*'
+      - 'mkdocs.yml'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Changelog
- Add paths so that `build-docs` only runs when there's been a change to docs-related files

