### PR TITLE
[WIP] Add CLI command: `submission`

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ conda activate cnb-tools
 pip install cnb-tools
 ```
 
-> [!NOTE]
+> ⓘ **NOTE**
+>
 > **cnb-tools** builds off of the Synapse Python Client — by
 > installing **cnb-tools**, you will also be installing **synapseclient**.
 >  
@@ -97,4 +98,4 @@ cnb-tools --version
 [miniforge]: https://github.com/conda-forge/miniforge
 [venv]: https://docs.python.org/3/library/venv.html
 [pyenv]: https://github.com/pyenv/pyenv
-[Read its docs.]: https://python-docs.synapse.org/build/html/index.html
+[Read its docs.]: https://python-docs.synapse.org/

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from typing import List
+
 from typing_extensions import Annotated
 import typer
 
@@ -7,11 +9,9 @@ app = typer.Typer()
 
 @app.command()
 def info(
-    submission_id: Annotated[
-        int, typer.Argument(help="Submission ID to [blue]get info[/blue]")
-    ]
+    submission_id: Annotated[int, typer.Argument(help="Submission ID to get info")]
 ):
-    """[bold blue]Get[/bold blue] information about a submission"""
+    """Get information about a submission"""
     print(f"ID: {submission_id}")
     print("Challenge: Awesome Challenge")
     print("Date: 2024-01-01")
@@ -22,15 +22,13 @@ def info(
 
 @app.command()
 def pull(
-    submission_id: Annotated[
-        int, typer.Argument(help="Submission ID to [blue]download[/blue]")
-    ],
+    submission_id: Annotated[int, typer.Argument(help="Submission ID to download")],
     dest: Annotated[
         Path,
-        typer.Option(..., "-d", "--dir", help="Directory to download submission into"),
+        typer.Option("--dir", "-d", help="Directory to download submission into (if submission is a file)"),
     ] = ".",
 ):
-    """[bold blue]Get[/bold blue] a submission (file/Docker image)"""
+    """Get a submission (file/Docker image)"""
     submission_type = "file"
     if submission_type == "file":
         print(f"Downloading {submission_id} to {dest}...")
@@ -41,57 +39,61 @@ def pull(
 
 @app.command()
 def annotate(
-    submission_id: Annotated[
-        int, typer.Argument(help="Submission ID to [orange1]annotate[/orange1]")
+    submission_ids: Annotated[
+        List[int],
+        typer.Argument(help="One or more submission ID(s) to annotate"),
     ],
+    annotations: Annotated[
         Path, typer.Argument(help="Filepath to JSON file", exists=True)
+    ],
 ):
-    """[bold orange1]Annotate[/bold orange1] a submission."""
-    print(f"Annotating {submission_id}...")
-    print("✅")
+    """Annotate one or more submission(s) with a JSON file."""
+    for submission in submission_ids:
+        print(f"Annotating {submission} with {annotations}...")
+        print("✅")
 
 
 @app.command()
 def update_status(
-    submission_id: Annotated[
-        int, typer.Argument(help="Submission ID to [orange1]update[/orange1]")
-    ],
+    submission_id: Annotated[List[int], typer.Argument(help="Submission ID to update")],
     new_status: Annotated[
         str, typer.Argument(help="One of [RECEIVED, VALIDATED, INVALID, ACCEPTED]")
-    ] = "ACCEPTED",
+    ],
 ):
-    """[bold orange1]Update[/bold orange1] a submission status."""
+    """Update a submission status."""
     print(f"Updating {submission_id} to status: {new_status}...")
     print("✅")
 
 
 @app.command()
 def reset(
-    submission_id: Annotated[
-        int, typer.Argument(help="Submission ID to [orange1]reset[/orange1]")
-    ],
+    submission_id: Annotated[int, typer.Argument(help="Submission ID to reset")],
 ):
-    """[bold orange1]Reset[/bold orange1] a submission status."""
+    """Reset a submission status."""
     print(f"Resetting {submission_id} to status RECEIVED...")
     print("✅")
 
 
 @app.command()
 def delete(
-    submission_id: Annotated[
-        int, typer.Argument(help="Submission ID to [red]delete[/red]")
+    submission_ids: Annotated[
+        List[int],
+        typer.Argument(help="One or more submission ID(s) to [red]delete[/red]"),
     ],
     force: Annotated[
         bool,
         typer.Option(
+            "--force",
+            "-f",
             prompt="Are you sure you want to delete the submission(s)?",
             help="Force [red]deletion[/red] without confirmation.",
         ),
-    ],
+    ] = False,
 ):
-    """[bold red]Delete[/bold red] one or more submissions."""
+    """Delete one or more submissions."""
     if force:
-        print(f"Deleting submissions: {submission_id}")
+        for submission in submission_ids:
+            print(f"Deleting submissions: {submission}")
         print("✅")
     else:
-        print("Nothing was done.")
+        print("No deletion was done.")

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -1,0 +1,93 @@
+from typing import Optional
+from typing_extensions import Annotated
+import typer
+
+app = typer.Typer()
+
+
+@app.command()
+def info(
+    submission_id: Annotated[
+        int, typer.Argument(help="Submission ID to [blue]get info[/blue]")
+    ]
+):
+    """[bold blue]Get[/bold blue] information about a submission"""
+    print(f"ID: {submission_id}")
+    print("Challenge: Awesome Challenge")
+    print("Date: 2024-01-01")
+    print("Submitter: awesome-user")
+    print("Team (if any): Awesome Team")
+    print("Status: SCORED")
+
+
+@app.command()
+def download(
+    submission_id: Annotated[
+        int, typer.Argument(help="Submission ID to [blue]download[/blue]")
+    ],
+    dest: Annotated[
+        str,
+        typer.Option(..., "-D", "--dir", help="Directory to download submission into"),
+    ] = ".",
+):
+    """[bold blue]Download[/bold blue] a submission"""
+    print(f"Downloading {submission_id} to {dest}...")
+    print("✅")
+
+
+@app.command()
+def annotate(
+    submission_id: Annotated[
+        int, typer.Argument(help="Submission ID to [orange1]annotate[/orange1]")
+    ],
+    annotations: Annotated[str, typer.Argument(help="Filepath to JSON file")],
+):
+    """[bold orange1]Annotate[/bold orange1] a submission."""
+    print(f"Annotating {submission_id}...")
+    print("✅")
+
+
+@app.command()
+def update_status(
+    submission_id: Annotated[
+        int, typer.Argument(help="Submission ID to [orange1]update[/orange1]")
+    ],
+    new_status: Annotated[
+        str, typer.Argument(help="One of [RECEIVED, VALIDATED, INVALID, ACCEPTED]")
+    ] = "ACCEPTED",
+):
+    """[bold orange1]Update[/bold orange1] a submission status."""
+    print(f"Updating {submission_id} to status: {new_status}...")
+    print("✅")
+
+
+@app.command()
+def reset(
+    submission_id: Annotated[
+        int, typer.Argument(help="Submission ID to [orange1]reset[/orange1]")
+    ],
+):
+    """[bold orange1]Reset[/bold orange1] a submission status."""
+    print(f"Resetting {submission_id} to status RECEIVED...")
+    print("✅")
+
+
+@app.command()
+def delete(
+    submission_id: Annotated[
+        int, typer.Argument(help="Submission ID to [red]delete[/red]")
+    ],
+    force: Annotated[
+        bool,
+        typer.Option(
+            prompt="Are you sure you want to delete the submission(s)?",
+            help="Force [red]deletion[/red] without confirmation.",
+        ),
+    ],
+):
+    """[bold red]Delete[/bold red] one or more submissions."""
+    if force:
+        print(f"Deleting submissions: {submission_id}")
+        print("✅")
+    else:
+        print("Nothing was done.")

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from pathlib import Path
 from typing_extensions import Annotated
 import typer
 
@@ -26,7 +26,7 @@ def pull(
         int, typer.Argument(help="Submission ID to [blue]download[/blue]")
     ],
     dest: Annotated[
-        str,
+        Path,
         typer.Option(..., "-d", "--dir", help="Directory to download submission into"),
     ] = ".",
 ):
@@ -44,7 +44,7 @@ def annotate(
     submission_id: Annotated[
         int, typer.Argument(help="Submission ID to [orange1]annotate[/orange1]")
     ],
-    annotations: Annotated[str, typer.Argument(help="Filepath to JSON file")],
+        Path, typer.Argument(help="Filepath to JSON file", exists=True)
 ):
     """[bold orange1]Annotate[/bold orange1] a submission."""
     print(f"Annotating {submission_id}...")

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -25,7 +25,11 @@ def pull(
     submission_id: Annotated[int, typer.Argument(help="Submission ID to download")],
     dest: Annotated[
         Path,
-        typer.Option("--dir", "-d", help="Directory to download submission into (if submission is a file)"),
+        typer.Option(
+            "--dir",
+            "-d",
+            help="Directory to download submission into (if submission is a file)",
+        ),
     ] = ".",
 ):
     """Get a submission (file/Docker image)"""

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -21,17 +21,21 @@ def info(
 
 
 @app.command()
-def download(
+def pull(
     submission_id: Annotated[
         int, typer.Argument(help="Submission ID to [blue]download[/blue]")
     ],
     dest: Annotated[
         str,
-        typer.Option(..., "-D", "--dir", help="Directory to download submission into"),
+        typer.Option(..., "-d", "--dir", help="Directory to download submission into"),
     ] = ".",
 ):
-    """[bold blue]Download[/bold blue] a submission"""
-    print(f"Downloading {submission_id} to {dest}...")
+    """[bold blue]Get[/bold blue] a submission (file/Docker image)"""
+    submission_type = "file"
+    if submission_type == "file":
+        print(f"Downloading {submission_id} to {dest}...")
+    else:
+        print("Pulling Docker image...")
     print("✅")
 
 

--- a/cnb_tools/main_cli.py
+++ b/cnb_tools/main_cli.py
@@ -1,22 +1,26 @@
 """Reference guide to cnb-tools CLI commands
 
-This module allows the user to manage challenges from the CLI.
+Manage challenges and benchmarking on Synapse from the CLI.
 
 Examples:
-    $ cnb-tools create-challenge -t 2
+    ```
+    $ cnb-tools create-challenge "challenge name" -t 2
+    ```
 
-This module contains the following commands:
+This CLI application contains the following commands:
 
 - `create-challenge` - Creates a new challenge on the Sage Challenge Portal
 """
-
 from typing import Optional
-
-import typer
-from cnb_tools import __version__
 from typing_extensions import Annotated
+import typer
 
-app = typer.Typer()
+from cnb_tools import __version__
+from cnb_tools.commands import submission_cli
+
+
+app = typer.Typer(rich_markup_mode="rich")
+app.add_typer(submission_cli.app, name="submission", help="Manage submissions")
 
 
 def version_callback(value: bool):
@@ -35,4 +39,8 @@ def main(
     """
     CNB Tools - convenience tools/functions for challenges and
     benchmarking on Synapse.org
+    
+    Some commands will require admin priviledges.  If you are a
+    challenge admin and are experiencing issues, contact us at
+    SageCNBTeam@synapse.org
     """

--- a/cnb_tools/main_cli.py
+++ b/cnb_tools/main_cli.py
@@ -29,8 +29,9 @@ def version_callback(value: bool):
         raise typer.Exit()
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def main(
+    ctx: typer.Context,
     version: Annotated[
         Optional[bool],
         typer.Option("--version", callback=version_callback, is_eager=True),
@@ -40,7 +41,11 @@ def main(
     CNB Tools - convenience tools/functions for challenges and
     benchmarking on Synapse.org
 
-    Some commands will require admin priviledges.  If you are a
-    challenge admin and are experiencing issues, contact us at
-    SageCNBTeam@synapse.org
+    [red](some commands will require admin priviledges)[/red]
+
+    If you are a challenge admin and are experiencing issues, contact us at
+    [bold blue]SageCNBTeam@synapse.org[/bold blue]
     """
+    if ctx.invoked_subcommand is None:
+        print("Manage challenges on Synapse.org from the CLI\n")
+        print("Enter `cnb-tools --help` for usage information.")

--- a/cnb_tools/main_cli.py
+++ b/cnb_tools/main_cli.py
@@ -39,7 +39,7 @@ def main(
     """
     CNB Tools - convenience tools/functions for challenges and
     benchmarking on Synapse.org
-    
+
     Some commands will require admin priviledges.  If you are a
     challenge admin and are experiencing issues, contact us at
     SageCNBTeam@synapse.org

--- a/docs/changelog/release-notes.md
+++ b/docs/changelog/release-notes.md
@@ -1,18 +1,27 @@
 ## In development
 
+### Features
+- CLI
+   * Annotate submission: `submission annotate <submission ID> <filepath to JSON file>`
+   * Download submission: `submission download <submission ID> --dest`
+   * Delete one or more submissions: `submission delete [--force] <submission ID 1> <submission ID 2> ...`
+   * Get information about submission: `submission info <submission ID>`
+   * Update submission status: `submission update-status <submission ID> <new status>`
+
+- Package
+   * New class: `Submission`
+
 ### Docs
 - add [Termynal plug-in](https://github.com/mkdocs-plugins/termynal)
 - mention using a Python environment before installing
 
 ## 0.1.1
 
-### Internal
 * Add Dockerfile for GH package.
 * Add CI workflow to deploy image on ghcr.io.
 
 ## 0.1.0
 
-### Internal
 * First commit. Prepare for PyPI publishing.
 * Add initial version of code, docs, etc.
 * Add CI workflows and templates.

--- a/docs/index.md
+++ b/docs/index.md
@@ -68,7 +68,7 @@ $ conda create -n cnb-tools python=3.12 -y
 $ conda activate cnb-tools
 
 # Install cnb-tools using pip
-$ pip install cnb-tools
+(cnb-tools) $ pip install cnb-tools
 ---> 100%
 Successfully installed cnb-tools
 ```
@@ -83,7 +83,7 @@ Verify the installation with:
 
 <!-- termynal -->
 ```console
-$ cnb-tools --version
+(cnb-tools) $ cnb-tools --version
 cnb-tools v0.1.1
 ```
 
@@ -101,4 +101,4 @@ cnb-tools v0.1.1
 [miniforge]: https://github.com/conda-forge/miniforge
 [venv]: https://docs.python.org/3/library/venv.html
 [pyenv]: https://github.com/pyenv/pyenv
-[Read its docs.]: https://python-docs.synapse.org/build/html/index.html
+[Read its docs.]: https://python-docs.synapse.org/

--- a/docs/user-guide/contributing.md
+++ b/docs/user-guide/contributing.md
@@ -38,14 +38,22 @@ Here is a typical contribution workflow:
 
 4. **Branch off `main` and develop your contribution**
 
-    Ensure `develop` is up-to-date in your local dev, then create
-    a new feature branch. We recommend prefixing the new branch name
-    with either `bug` or `feat` — depending on what you're working
-    on — followed by its GH tracking number:
+    Ensure `main` is up-to-date in your local dev, then create a new
+    feature branch. We recommend prefixing the new branch name with
+    either `bug` or `feat` — depending on what you're working on -
+    followed by its GitHub tracking number:
 
     ```
     git checkout main && git pull
     git checkout -b <feat/bug-123> main
+    ```
+
+    If there is not an associating GitHub ticket, use a concise descriptive
+    title, like:
+
+    ```
+    feat-add_submission_module
+    bug-fix_readme_typos
     ```
 
 5. **Document your changes**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,7 +56,10 @@ plugins:
 - search
 - mkdocstrings
 - autorefs
-- termynal
+- termynal:
+    prompt_literal_start:
+          - "$"
+          - "(cnb-tools) $"
 
 extra:
   social:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cnb-tools"
-version = "0.1.1"
+version = "0.2.0"
 description = "Convenience tools/functions for challenges and benchmarking on Synapse.org"
 license = "Apache-2.0"
 authors = ["Sage CNB Team <cnb@sagebase.org>"]
@@ -11,7 +11,7 @@ readme = "README.md"
 repository = "https://github.com/Sage-Bionetworks-Challenges/cnb-tools"
 documentation = "https://sage-bionetworks-challenges.github.io/cnb-tools"
 classifiers = [
-    "Development Status :: 1 - Planning",
+    "Development Status :: 2 - Pre-Alpha",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: Apache Software License",


### PR DESCRIPTION
This is a WIP; functionality of subcommands will be completed in subsequent PRs.

## Changelog
* Add new command to CLI application: `submission`
* Add placeholder subcommands:

Subcommand | Description
--|--
`annotate` | Annotate a submission
`delete` | Delete one or more submissions
`info` | Get general information about a submission
`pull` | Download a submission (flat file or Docker image)
`reset` | Change a submission status to RECEIVED
`update-status` | Update a submission status to one of [RECEIVED, VALIDATED, INVALID, OPEN, CLOSED, SCORED, ACCEPTED]

## Preview

![Screenshot 2024-01-16 at 11 14 57 AM](https://github.com/Sage-Bionetworks-Challenges/cnb-tools/assets/9377970/cc60ca19-d624-4021-83a4-f816e8c18713)
