### PR TITLE
[fix] add `skip-errors` to select subcommands

### DIFF
--- a/cnb_tools/classes/annotation.py
+++ b/cnb_tools/classes/annotation.py
@@ -2,6 +2,7 @@
 
 import json
 
+from synapseclient import SubmissionStatus
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.core.retry import with_retry
 
@@ -9,7 +10,7 @@ from cnb_tools.classes.base import SynapseBase, UnknownSynapseID
 
 
 class SubmissionAnnotation(SynapseBase):
-    def __init__(self, sub_id):
+    def __init__(self, sub_id: int):
         super().__init__(sub_id)
         try:
             self._curr_annotations = self.syn.getSubmissionStatus(sub_id)
@@ -20,12 +21,12 @@ class SubmissionAnnotation(SynapseBase):
             ) from err
 
     @property
-    def curr_annotations(self) -> list[str]:
+    def curr_annotations(self) -> SubmissionStatus:
         """Submission's current list of annotations."""
         return self._curr_annotations
 
     @curr_annotations.setter
-    def curr_annotations(self, value: list[str]):
+    def curr_annotations(self, value: SubmissionStatus):
         self._curr_annotations = value
 
     def __str__(self) -> str:
@@ -34,7 +35,12 @@ class SubmissionAnnotation(SynapseBase):
         to_print += json.dumps(self.curr_annotations.submissionAnnotations, indent=2)
         return to_print
 
-    def update(self, new_annots, verbose) -> None:
+    # pylint: disable=unsupported-binary-operation
+    def update(
+            self,
+            new_annots: dict[str, str | int | float | bool],
+            verbose: bool
+        ) -> None:
         self.curr_annotations.submissionAnnotations.update(new_annots)
         self.curr_annotations = self.syn.store(self.curr_annotations)
         print(f"Submission ID {self.uid} annotations updated.")
@@ -43,7 +49,7 @@ class SubmissionAnnotation(SynapseBase):
             print("Annotations:")
             print(json.dumps(self.curr_annotations.submissionAnnotations, indent=2))
 
-    def update_with_file(self, annots_file, verbose) -> None:
+    def update_with_file(self, annots_file: str, verbose: bool) -> None:
         with open(annots_file, encoding="utf-8") as f:
             new_annots = json.load(f)
 
@@ -61,7 +67,7 @@ class SubmissionAnnotation(SynapseBase):
             verbose=True,
         )
 
-    def update_status(self, new_status) -> None:
+    def update_status(self, new_status: str) -> None:
         self.curr_annotations.status = new_status
         self.syn.store(self.curr_annotations)
         print(f"Updated saubmission ID {self.uid} to status: {new_status}")

--- a/cnb_tools/classes/annotation.py
+++ b/cnb_tools/classes/annotation.py
@@ -36,12 +36,12 @@ class SubmissionAnnotation(SynapseBase):
 
     def update(self, new_annots, verbose) -> None:
         self.curr_annotations.submissionAnnotations.update(new_annots)
-        curr_annotations = self.syn.store(self.curr_annotations)
+        self.curr_annotations = self.syn.store(self.curr_annotations)
         print(f"Submission ID {self.uid} annotations updated.")
 
         if verbose:
             print("Annotations:")
-            print(json.dumps(curr_annotations.submissionAnnotations, indent=2))
+            print(json.dumps(self.curr_annotations.submissionAnnotations, indent=2))
 
     def update_with_file(self, annots_file, verbose) -> None:
         with open(annots_file, encoding="utf-8") as f:

--- a/cnb_tools/classes/annotation.py
+++ b/cnb_tools/classes/annotation.py
@@ -70,4 +70,4 @@ class SubmissionAnnotation(SynapseBase):
     def update_status(self, new_status: str) -> None:
         self.curr_annotations.status = new_status
         self.syn.store(self.curr_annotations)
-        print(f"Updated saubmission ID {self.uid} to status: {new_status}")
+        print(f"Updated submission ID {self.uid} to status: {new_status}")

--- a/cnb_tools/classes/base.py
+++ b/cnb_tools/classes/base.py
@@ -15,7 +15,7 @@ class SynapseBase:
         return self._syn
 
     @syn.setter
-    def syn(self, _: str):
+    def syn(self, _: str) -> None:
         raise SynapseInternalError("syn object is read-only")
 
     @property
@@ -24,7 +24,7 @@ class SynapseBase:
         return self._uid
 
     @uid.setter
-    def uid(self, value: str):
+    def uid(self, value: str) -> None:
         self._uid = value
 
     # pylint: disable=unsupported-binary-operation

--- a/cnb_tools/classes/participant.py
+++ b/cnb_tools/classes/participant.py
@@ -16,7 +16,13 @@ class Participant(SynapseBase):
         except SynapseHTTPError:
             return self.syn.getUserProfile(self.uid).get("userName")
 
-    def create_team(self, name, description=None, can_public_join=False) -> Team:
+    # pylint: disable=unsupported-binary-operation
+    def create_team(
+        self,
+        name: str,
+        description: str | None = None,
+        can_public_join: bool = False
+    ) -> Team:
         try:
             team = self.syn.getTeam(name)
             use_team = typer.confirm(f"Team '{name}' already exists. Use this team?")

--- a/cnb_tools/classes/queue.py
+++ b/cnb_tools/classes/queue.py
@@ -19,11 +19,11 @@ class Queue(SynapseBase):
 
     @property
     def queue(self) -> Evaluation:
-        """Synapse entity's unique ID."""
+        """Synapse evaluation queue."""
         return self._queue
 
     @queue.setter
-    def queue(self, value: Evaluation):
+    def queue(self, value: Evaluation) -> None:
         self._queue = value
 
     def __str__(self) -> str:

--- a/cnb_tools/classes/submission.py
+++ b/cnb_tools/classes/submission.py
@@ -1,12 +1,10 @@
 """Class representing a challenge submission."""
 
-import sys
-
 from pathlib import Path
 from synapseclient.core.exceptions import SynapseHTTPError
 
 from cnb_tools.classes.annotation import SubmissionAnnotation
-from cnb_tools.classes.base import SynapseBase
+from cnb_tools.classes.base import SynapseBase, UnknownSynapseID
 from cnb_tools.classes.participant import Participant
 from cnb_tools.classes.queue import Queue
 
@@ -17,11 +15,10 @@ class Submission(SynapseBase):
         try:
             self._submission = self.syn.getSubmission(sub_id, downloadFile=False)
         except SynapseHTTPError as err:
-            print(
+            raise UnknownSynapseID(
                 f"⛔ {err.response.json().get('reason')}. "
                 "Check the ID and try again."
-            )
-            sys.exit(1)
+            ) from err
 
     @property
     def submission(self):

--- a/cnb_tools/classes/submission.py
+++ b/cnb_tools/classes/submission.py
@@ -12,16 +12,25 @@ from cnb_tools.classes.queue import Queue
 
 
 class Submission(SynapseBase):
-    def __init__(self, sub_id):
+    def __init__(self, sub_id: int):
         super().__init__(sub_id)
         try:
-            self.submission = self.syn.getSubmission(sub_id, downloadFile=False)
+            self._submission = self.syn.getSubmission(sub_id, downloadFile=False)
         except SynapseHTTPError as err:
             print(
                 f"⛔ {err.response.json().get('reason')}. "
                 "Check the ID and try again."
             )
             sys.exit(1)
+
+    @property
+    def submission(self):
+        """Synapse submission."""
+        return self._submission
+
+    @submission.setter
+    def submission(self, value) -> None:
+        self._sumission = value
 
     def delete(self) -> None:
         self.syn.delete(self.submission)

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -57,11 +57,24 @@ def change_status(
         list[int], typer.Argument(help="One or more submission ID(s)")
     ],
     new_status: Annotated[Status, typer.Argument()],
+    skip_errors: Annotated[
+        bool,
+        typer.Option(
+            "--skip_errors",
+            help="Continue update even if unknown ID error is encountered (default: False)",
+        ),
+    ] = False,
 ):
     """Update one or more submission statuses."""
     for submission_id in submission_ids:
-        submission_annots = SubmissionAnnotation(submission_id)
-        submission_annots.update_status(new_status)
+        try:
+            submission_annots = SubmissionAnnotation(submission_id)
+            submission_annots.update_status(new_status)
+        except UnknownSynapseID as err:
+            if skip_errors:
+                print(f"Unknown submission ID: {submission_id} - skipping...")
+                continue
+            sys.exit(err)
 
 
 @app.command()
@@ -82,13 +95,26 @@ def delete(
             help="Force [red]deletion[/red] without confirmation.",
         ),
     ] = False,
+    skip_errors: Annotated[
+        bool,
+        typer.Option(
+            "--skip_errors",
+            help="Continue deletion even if unknown ID error is encountered (default: False)",
+        ),
+    ] = False,
 ):
     """Delete one or more submissions."""
     print()
     if force:
         for submission_id in submission_ids:
-            submission = Submission(submission_id)
-            submission.delete()
+            try:
+                submission = Submission(submission_id)
+                submission.delete()
+            except UnknownSynapseID as err:
+                if skip_errors:
+                    print(f"Unknown submission ID: {submission_id} - skipping...")
+                    continue
+                sys.exit(err)
     else:
         print("No deletion was done.")
 
@@ -135,6 +161,17 @@ def reset(
     submission_ids: Annotated[
         list[int], typer.Argument(help="One or more submission ID(s)")
     ],
+    skip_errors: Annotated[
+        bool,
+        typer.Option(
+            "--skip_errors",
+            help="Continue update even if unknown ID error is encountered (default: False)",
+        ),
+    ] = False,
 ):
     """Reset one or more submission to RECEIVED."""
-    change_status(submission_ids=submission_ids, new_status="RECEIVED")
+    change_status(
+        submission_ids=submission_ids,
+        new_status="RECEIVED",
+        skip_errors=skip_errors
+    )

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -6,12 +6,14 @@ Example:
     $ cnb-tools submission --help
 """
 
+import sys
 from pathlib import Path
 
 from enum import Enum
 from typing_extensions import Annotated
 import typer
 
+from cnb_tools.classes.base import UnknownSynapseID
 from cnb_tools.classes.annotation import SubmissionAnnotation
 from cnb_tools.classes.submission import Submission
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -123,13 +123,13 @@ Replace the following:
 
 Options:
 
-| Name        | Type    | Description                                  | Default |
-| ----------- | ------- | -------------------------------------------- | ------- |
-| `--verbose` | boolean | Output the submission status and annotations | False   |
+Name | Type | Description | Default
+--|--|--|--
+`--verbose` | boolean | Output the submission status and annotations | False
 
 ### `reset`
 
-Reset one or more submission(s) (that is: set `status` to `RECEIVED`).
+Reset one or more submission(s) (set `status` to `RECEIVED`).
 
 ```bash
 cnb-tools submission reset SUB_ID ...
@@ -137,7 +137,7 @@ cnb-tools submission reset SUB_ID ...
 
 Replace the following:
 
-- _`SUB_ID ...`_ - submission ID(s))
+- _`SUB_ID ...`_ - submission ID(s)
 
 ---
 


### PR DESCRIPTION
Fixes #22

## Changelog
<!-- Itemize the changes made in this PR -->

- Add `skip-errors` (boolean) to `submission` subcommands:
   - `change-status`
   - `delete`
   - `reset` 
   
   This option will allow users to continue updating/deleting even if an unknown ID is given among the list of submission IDs. Without the flag, the subcommands will continue to behave as before, that is, it'll stop running the action once an unknown ID is encountered.

- Other minor fixes, e.g. add missing type-hints, typo fixes, etc.

## Preview

**Before**

```
$ cnb-tools submission change-status 1 9743567 3 CLOSED
⛔ Cannot find submission or status for id 1. Check the ID and try again.
```

**After (without `skip-errors` - no change from before)**

```
$ cnb-tools submission change-status 1 9743567 3 CLOSED
⛔ Cannot find submission or status for id 1. Check the ID and try again.
```

**After (with `skip-errors`)**

```
$ cnb-tools submission change-status 1 9743567 3 CLOSED --skip_errors
Unknown submission ID: 1 - skipping...
Updated saubmission ID 9743567 to status: Status.closed
Unknown submission ID: 3 - skipping...
```
