### PR TITLE
[fix] update base image version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-alpine 
+FROM python:3.12-slim
 
 WORKDIR /root/cnb-tools
 


### PR DESCRIPTION
Fixes #29 

## Changelog
- Use `python:3.12-slim` instead of `alpine` (which may be too minimal for cnb-tools)

