### PR TITLE
[feat] Get submission contributors

### DIFF
--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -155,9 +155,10 @@ def get(
     """Get information about a submission"""
     if as_json:
         import json
+        import dataclasses
 
         sub = submission.get_submission(submission_id)
-        typer.echo(json.dumps(dict(sub), indent=2, default=str))
+        typer.echo(json.dumps(dataclasses.asdict(sub), indent=2, default=str))
     else:
         submission.print_submission_info(submission_id, verbose)
 

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -163,6 +163,36 @@ def get(
 
 
 @app.command()
+def get_contributors(
+    submission_id: Annotated[int, typer.Argument(help="Submission ID")],
+):
+    """Get contributors for a submission."""
+    sub = submission.get_submission(submission_id)
+
+    if sub.team_id:
+        team = (
+            submission.get_submitter_name(sub.team_id)
+            if human_readable
+            else sub.team_id
+        )
+        typer.echo(f"Team: {team}\n")
+
+    contributors = submission.get_submission_contributors(submission_id)
+    if contributors:
+        typer.echo("Contributors:")
+        for user in contributors:
+            principal_id = user.get("principalId")
+            name = (
+                submission.get_submitter_name(int(principal_id))
+                if human_readable
+                else principal_id
+            )
+            typer.echo(f"  {name}")
+    else:
+        typer.echo("No contributors found.")
+
+
+@app.command()
 def reset(
     submission_ids: Annotated[
         list[int], typer.Argument(help="One or more submission ID(s)")

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -165,6 +165,14 @@ def get(
 @app.command()
 def get_contributors(
     submission_id: Annotated[int, typer.Argument(help="Submission ID")],
+    human_readable: Annotated[
+        bool,
+        typer.Option(
+            "--pretty-print",
+            "-pp",
+            help="Resolve IDs to team/user names (default: false)",
+        ),
+    ] = False,
 ):
     """Get contributors for a submission."""
     sub = submission.get_submission(submission_id)

--- a/cnb_tools/modules/submission.py
+++ b/cnb_tools/modules/submission.py
@@ -146,10 +146,10 @@ def print_submission_info(
     challenge_display = get_challenge_name(sub.evaluation_id)
     submitter_display = get_submitter_name(submitter_id)
 
-    print(f"         ID: {submission_id}")
-    print(f"  Challenge: {challenge}")
-    print(f"       Date: {sub.created_on[:10]}")
-    print(f"  Submitter: {submitter}")
+    print(f"ID:        {submission_id}")
+    print(f"Challenge: {challenge_display}")
+    print(f"Date:      {sub.created_on[:10]}")
+    print(f"Submitter: {submitter_display}")
 
     if verbose:
         status = annotation.get_submission_status(submission_id)

--- a/cnb_tools/modules/submission.py
+++ b/cnb_tools/modules/submission.py
@@ -156,7 +156,7 @@ def print_submission_info(
         print(annotation.format_annotations(status))
 
 
-def get_submission_contributors(submission_id: int) -> list[str]:
+def get_submission_contributors(submission_id: int) -> list[dict[str, object]]:
     """Get the contributors for a single submission from its metadata.
 
     Tip: Example Use Case
@@ -167,7 +167,8 @@ def get_submission_contributors(submission_id: int) -> list[str]:
       submission_id: ID of the submission.
 
     Returns:
-      List of Synapse principal IDs (strings) for the submission's contributors.
+      List of contributor records from the submission metadata (each record
+      includes at least ``principalId`` and ``createdOn``).
 
     Raises:
       UnknownSynapseID: If the submission ID is invalid.

--- a/cnb_tools/modules/submission.py
+++ b/cnb_tools/modules/submission.py
@@ -130,17 +130,21 @@ def get_challenge_name(evaluation_id: int) -> str:
         ) from err
 
 
-def print_submission_info(submission_id: int, verbose: bool = False) -> None:
+def print_submission_info(
+    submission_id: int, verbose: bool = False, pretty_print: bool = False
+) -> None:
     """Print information about a submission.
 
     Args:
         submission_id: ID of the submission
         verbose: If True, also print submission annotations
+        pretty_print: If True, resolve IDs to human-readable names
     """
     sub = get_submission(submission_id)
-    challenge = get_challenge_name(sub.evaluation_id)
     submitter_id = sub.team_id or sub.user_id
-    submitter = get_submitter_name(submitter_id)
+
+    challenge_display = get_challenge_name(sub.evaluation_id)
+    submitter_display = get_submitter_name(submitter_id)
 
     print(f"         ID: {submission_id}")
     print(f"  Challenge: {challenge}")

--- a/cnb_tools/modules/submission.py
+++ b/cnb_tools/modules/submission.py
@@ -131,14 +131,14 @@ def get_challenge_name(evaluation_id: int) -> str:
 
 
 def print_submission_info(
-    submission_id: int, verbose: bool = False, pretty_print: bool = False
+    submission_id: int,
+    verbose: bool = False,
 ) -> None:
     """Print information about a submission.
 
     Args:
         submission_id: ID of the submission
         verbose: If True, also print submission annotations
-        pretty_print: If True, resolve IDs to human-readable names
     """
     sub = get_submission(submission_id)
     submitter_id = sub.team_id or sub.user_id

--- a/cnb_tools/modules/submission.py
+++ b/cnb_tools/modules/submission.py
@@ -152,6 +152,26 @@ def print_submission_info(submission_id: int, verbose: bool = False) -> None:
         print(annotation.format_annotations(status))
 
 
+def get_submission_contributors(submission_id: int) -> list[str]:
+    """Get the contributors for a single submission from its metadata.
+
+    Tip: Example Use Case
+      Quickly list everyone credited on a specific submission without
+      scanning an entire evaluation queue.
+
+    Args:
+      submission_id: ID of the submission.
+
+    Returns:
+      List of Synapse principal IDs (strings) for the submission's contributors.
+
+    Raises:
+      UnknownSynapseID: If the submission ID is invalid.
+    """
+    sub = get_submission(submission_id)
+    return list(sub.contributors) if sub.contributors else []
+
+
 def get_contributors(
     evaluation_ids: list[int | str],
     status: str = "SCORED",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,24 @@ def mock_submission_file():
     sub.team_id = 111
     sub.user_id = 222
     sub.docker_digest = None
+    sub.contributors = None
+    return sub
+
+
+@pytest.fixture
+def mock_submission_with_contributors():
+    """Fixture for mocked team submission with contributors."""
+    sub = MagicMock(spec=ModelSubmission)
+    sub.id = "12345"
+    sub.evaluation_id = "98765"
+    sub.created_on = "2025-11-26T10:30:00.000Z"
+    sub.team_id = 111
+    sub.user_id = None
+    sub.docker_digest = None
+    sub.contributors = [
+        {"principalId": "333", "createdOn": "2025-11-26T10:30:00.000Z"},
+        {"principalId": "444", "createdOn": "2025-11-26T10:30:00.000Z"},
+    ]
     return sub
 
 

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -164,9 +164,9 @@ class TestPrintSubmissionInfo:
         submission.print_submission_info(12345, verbose=False)
 
         captured = capsys.readouterr()
-        assert "ID: 12345" in captured.out
+        assert "ID:        12345" in captured.out
         assert "Challenge: Test Challenge" in captured.out
-        assert "Date: 2025-11-26" in captured.out
+        assert "Date:      2025-11-26" in captured.out
         assert "Submitter: Test Team" in captured.out
 
     @patch("cnb_tools.modules.submission.annotation")
@@ -194,3 +194,33 @@ class TestPrintSubmissionInfo:
 
         mock_annotation.get_submission_status.assert_called_once_with(12345)
         mock_annotation.format_annotations.assert_called_once_with(mock_status)
+
+
+class TestGetSubmissionContributors:
+    """Tests for get_submission_contributors function"""
+
+    @patch("cnb_tools.modules.submission.get_submission")
+    def test_returns_contributor_ids(
+        self, mock_get_sub, mock_submission_with_contributors
+    ):
+        """Test that contributor principal IDs are returned"""
+        mock_get_sub.return_value = mock_submission_with_contributors
+
+        result = submission.get_submission_contributors(12345)
+
+        assert result == [
+            {"principalId": "333", "createdOn": "2025-11-26T10:30:00.000Z"},
+            {"principalId": "444", "createdOn": "2025-11-26T10:30:00.000Z"},
+        ]
+        mock_get_sub.assert_called_once_with(12345)
+
+    @patch("cnb_tools.modules.submission.get_submission")
+    def test_returns_empty_list_when_no_contributors(
+        self, mock_get_sub, mock_submission_file
+    ):
+        """Test that an empty list is returned when there are no contributors"""
+        mock_get_sub.return_value = mock_submission_file
+
+        result = submission.get_submission_contributors(12345)
+
+        assert result == []


### PR DESCRIPTION
## Changelog
- Add get_submission_contributors() to retrieve contributors for a single submission from its metadata
- Add CLI command for getting submission contributors
- Fix bug for returning output as json (`--json`)

## Preview

```
$ cnb-tools submission get-contributors 9767546
Team: 3585277

Contributors:
  3393723
  3450172
```

```
$ cnb-tools submission get-contributors 9767546 -pp 
Team: verena_brats_test

Contributors:
  vchung
  astaraki
```
