### PR TITLE
[feat] Disable team email

### DIFF
--- a/cnb_tools/modules/new_challenge.py
+++ b/cnb_tools/modules/new_challenge.py
@@ -279,10 +279,10 @@ def close_challenge(project_id: str) -> None:
         permissions.set_evaluation_permissions(
             eval_id, participant_team_id, permission_level="view"
         )
-        logger.info(
-            f"Evaluation {eval_id}: participant team downgraded to view-only"
-        )
+        logger.info(f"Evaluation {eval_id}: participant team downgraded to view-only")
 
     # 3. Lock the participant team
     participant.lock_team(participant_team_id)
-    logger.info(f"Participant team {participant_team_id} locked (no public join or requests)")
+    logger.info(
+        f"Participant team {participant_team_id} locked (no public join or requests)"
+    )

--- a/cnb_tools/modules/new_challenge.py
+++ b/cnb_tools/modules/new_challenge.py
@@ -177,6 +177,7 @@ def main(
     """
     syn = get_synapse_client()
     teams = _create_teams(challenge_name)
+    participant.disable_team_email(teams["participant_team_id"])
 
     # --- Project -------------------------------------------------------
     if live_site is None:

--- a/cnb_tools/modules/participant.py
+++ b/cnb_tools/modules/participant.py
@@ -121,3 +121,27 @@ def lock_team(team_id: int | str) -> None:
     team_data["canPublicJoin"] = False
     team_data["canRequestMembership"] = False
     syn.restPUT("/team", json.dumps(team_data))
+
+
+def disable_team_email(team_id: int | str) -> None:
+    """Prevent non-members from sending emails to a team.
+
+    Modifies the team ACL so that the team's own entry only has READ
+    access, removing any SEND_MESSAGE permission. This stops random
+    Synapse users from emailing the entire participant team.
+
+    Tip: Example Use Case
+      Lock down the Participants team inbox so that participants cannot
+      mass-email each other and are directed to the discussion forum or
+      organizers instead.
+
+    Args:
+      team_id: Synapse Team ID.
+    """
+    syn = get_synapse_client()
+    acl = syn.restGET(f"/team/{team_id}/acl")
+    for entry in acl.get("resourceAccess", []):
+        if entry.get("principalId") == int(team_id):
+            entry["accessType"] = ["READ"]
+            break
+    syn.restPUT("/team/acl", json.dumps(acl))

--- a/cnb_tools/modules/participant.py
+++ b/cnb_tools/modules/participant.py
@@ -124,11 +124,11 @@ def lock_team(team_id: int | str) -> None:
 
 
 def disable_team_email(team_id: int | str) -> None:
-    """Prevent non-members from sending emails to a team.
+    """Prevent team members from sending emails to the entire team.
 
-    Modifies the team ACL so that the team's own entry only has READ
-    access, removing any SEND_MESSAGE permission. This stops random
-    Synapse users from emailing the entire participant team.
+    Modifies the team ACL entry for the team principal (principalId == team_id)
+    to remove the SEND_MESSAGE permission, preventing participants from mass-emailing
+    the Participants team.
 
     Tip: Example Use Case
       Lock down the Participants team inbox so that participants cannot

--- a/tests/test_participant.py
+++ b/tests/test_participant.py
@@ -8,7 +8,6 @@ from synapseclient.models import Team
 from cnb_tools.modules import participant
 
 
-
 class TestCreateTeam:
     """Tests for create_team function"""
 
@@ -67,3 +66,49 @@ class TestCreateTeam:
             participant.create_team(name="Existing Team")
 
         assert "Try again with a new challenge name" in str(exc_info.value)
+
+
+class TestDisableTeamEmail:
+    """Tests for disable_team_email function"""
+
+    @patch("cnb_tools.modules.participant.get_synapse_client")
+    def test_removes_send_message_from_team_acl(self, mock_get_client, mock_syn):
+        """Test that the team's ACL entry is reduced to READ only"""
+        mock_get_client.return_value = mock_syn
+        mock_syn.restGET.return_value = {
+            "id": "123",
+            "resourceAccess": [
+                {"principalId": 123, "accessType": ["READ", "SEND_MESSAGE"]},
+                {"principalId": 456, "accessType": ["READ", "SEND_MESSAGE", "UPDATE"]},
+            ],
+        }
+
+        participant.disable_team_email(123)
+
+        mock_syn.restGET.assert_called_once_with("/team/123/acl")
+        put_payload = mock_syn.restPUT.call_args
+        import json
+
+        acl = json.loads(put_payload[0][1])
+        team_entry = next(e for e in acl["resourceAccess"] if e["principalId"] == 123)
+        assert team_entry["accessType"] == ["READ"]
+
+    @patch("cnb_tools.modules.participant.get_synapse_client")
+    def test_does_not_modify_other_acl_entries(self, mock_get_client, mock_syn):
+        """Test that only the team's own ACL entry is modified"""
+        mock_get_client.return_value = mock_syn
+        mock_syn.restGET.return_value = {
+            "id": "123",
+            "resourceAccess": [
+                {"principalId": 123, "accessType": ["READ", "SEND_MESSAGE"]},
+                {"principalId": 456, "accessType": ["READ", "SEND_MESSAGE", "UPDATE"]},
+            ],
+        }
+
+        participant.disable_team_email(123)
+
+        import json
+
+        acl = json.loads(mock_syn.restPUT.call_args[0][1])
+        other_entry = next(e for e in acl["resourceAccess"] if e["principalId"] == 456)
+        assert "SEND_MESSAGE" in other_entry["accessType"]


### PR DESCRIPTION
Fixes #32

## Changelog
- Add logic for restricting a participant from emailing the entire Participants team
- When creating a new challenge, the participants team will disable email by default

