### PR TITLE
[feat] Export functions into __init__

### DIFF
--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -113,4 +113,9 @@ __all__ = [
     "print_submission_info",
     "get_submission_contributors",
     "get_contributors",
+    "__version__",
 ]
+
+
+def __dir__() -> list[str]:
+    return sorted(__all__)

--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -20,10 +20,25 @@ from cnb_tools.modules.client import (
     SynapseLoginError,
     UnknownSynapseID,
 )
-from cnb_tools.modules.new_challenge import (
-    main as create_new_challenge,
-    close_challenge,
-)
+try:
+    from cnb_tools.modules.new_challenge import main as create_new_challenge, close_challenge
+except ModuleNotFoundError as err:
+    # Avoid breaking `import cnb_tools` if the optional `synapseutils` dependency
+    # is not installed.
+    if err.name != "synapseutils":
+        raise
+
+    def create_new_challenge(*args, **kwargs):
+        raise ModuleNotFoundError(
+            "Optional dependency 'synapseutils' is required for create_new_challenge(). "
+            "Install it with `pip install synapseutils`."
+        ) from err
+
+    def close_challenge(*args, **kwargs):
+        raise ModuleNotFoundError(
+            "Optional dependency 'synapseutils' is required for close_challenge(). "
+            "Install it with `pip install synapseutils`."
+        ) from err
 from cnb_tools.modules.participant import (
     get_participant_name,
     create_team,

--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -21,7 +21,10 @@ from cnb_tools.modules.client import (
     UnknownSynapseID,
 )
 try:
-    from cnb_tools.modules.new_challenge import main as create_new_challenge, close_challenge
+    from cnb_tools.modules.new_challenge import (
+        close_challenge,
+        main as create_new_challenge,
+    )
 except ModuleNotFoundError as err:
     # Avoid breaking `import cnb_tools` if the optional `synapseutils` dependency
     # is not installed.

--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -1,3 +1,101 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version("cnb-tools")
+
+from cnb_tools.modules.annotation import (
+    get_submission_status,
+    format_annotations,
+    update_annotations,
+    update_annotations_from_file,
+    update_submission_status,
+)
+from cnb_tools.modules.challenge import (
+    get_challenge,
+    create_challenge,
+    delete_challenge,
+    get_registered_teams,
+)
+from cnb_tools.modules.client import (
+    get_synapse_client,
+    SynapseLoginError,
+    UnknownSynapseID,
+)
+from cnb_tools.modules.new_challenge import (
+    main as create_new_challenge,
+    close_challenge,
+)
+from cnb_tools.modules.participant import (
+    get_participant_name,
+    create_team,
+    remove_team_member,
+    get_team_member_count,
+    lock_team,
+    disable_team_email,
+)
+from cnb_tools.modules.permissions import (
+    set_entity_permissions,
+    set_evaluation_permissions,
+)
+from cnb_tools.modules.queue import (
+    get_evaluation,
+    get_evaluation_ids_by_project,
+    get_challenge_name_from_evaluation,
+    create_evaluation,
+    create_evaluation_round,
+)
+from cnb_tools.modules.submission import (
+    get_submission,
+    delete_submission,
+    download_submission,
+    get_submitter_name,
+    get_challenge_name,
+    print_submission_info,
+    get_submission_contributors,
+    get_contributors,
+)
+
+__all__ = [
+    # annotation
+    "get_submission_status",
+    "format_annotations",
+    "update_annotations",
+    "update_annotations_from_file",
+    "update_submission_status",
+    # challenge
+    "get_challenge",
+    "create_challenge",
+    "delete_challenge",
+    "get_registered_teams",
+    # client
+    "get_synapse_client",
+    "SynapseLoginError",
+    "UnknownSynapseID",
+    # new_challenge
+    "create_new_challenge",
+    "close_challenge",
+    # participant
+    "get_participant_name",
+    "create_team",
+    "remove_team_member",
+    "get_team_member_count",
+    "lock_team",
+    "disable_team_email",
+    # permissions
+    "set_entity_permissions",
+    "set_evaluation_permissions",
+    # queue
+    "get_evaluation",
+    "get_evaluation_ids_by_project",
+    "get_challenge_name_from_evaluation",
+    "create_evaluation",
+    "create_evaluation_round",
+    # submission
+    "get_submission",
+    "delete_submission",
+    "download_submission",
+    "get_submitter_name",
+    "get_challenge_name",
+    "print_submission_info",
+    "get_submission_contributors",
+    "get_contributors",
+]


### PR DESCRIPTION
## Changelog
- Expose all public module functions so that they are importable from `cnb_tools`
- Use `__all__` to enforce the public API

## Preview

**Before**

Auto-tabbing on `cnb_tools` returns `importlib`:

```python
>>> import cnb_tools
>>> cnb_tools.importlib
cnb_tools.importlib
```

**After**

Auto-tabbing on `cnb_tools` now returns the convenience functions:

```python
>>> import cnb_tools
>>> cnb_tools.
cnb_tools.close_challenge(                   
cnb_tools.create_challenge(                  
cnb_tools.create_evaluation(                 
cnb_tools.create_evaluation_round(           
cnb_tools.create_new_challenge(              
... [truncated]
```
