### PR TITLE
Fix/43

### DIFF
--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -7,6 +7,8 @@ from cnb_tools.modules.annotation import (
     format_annotations,
     update_annotations,
     update_annotations_from_file,
+    update_legacy_annotations,
+    update_legacy_annotations_from_file,
     update_submission_status,
 )
 from cnb_tools.modules.challenge import (
@@ -20,6 +22,7 @@ from cnb_tools.modules.client import (
     SynapseLoginError,
     UnknownSynapseID,
 )
+
 try:
     from cnb_tools.modules.new_challenge import (
         close_challenge,
@@ -42,6 +45,8 @@ except ModuleNotFoundError as err:
             "Optional dependency 'synapseutils' is required for close_challenge(). "
             "Install it with `pip install synapseutils`."
         ) from err
+
+
 from cnb_tools.modules.participant import (
     get_participant_name,
     create_team,
@@ -78,6 +83,8 @@ __all__ = [
     "format_annotations",
     "update_annotations",
     "update_annotations_from_file",
+    "update_legacy_annotations",
+    "update_legacy_annotations_from_file",
     "update_submission_status",
     # challenge
     "get_challenge",

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -31,11 +31,16 @@ app = typer.Typer()
 
 @app.command()
 def annotate(
-    submission_id: Annotated[int, typer.Argument(help="Submission ID")],
+    submission_ids: Annotated[
+        list[int], typer.Argument(help="One or more submission ID(s)")
+    ],
     json_file: Annotated[
         Path,
-        typer.Argument(
-            help="Filepath to JSON file containing annotations", exists=True
+        typer.Option(
+            "--file",
+            "-f",
+            help="Filepath to JSON file containing annotations",
+            exists=True,
         ),
     ],
     verbose: Annotated[
@@ -46,9 +51,45 @@ def annotate(
             help="Output final submission annotations (default: false)",
         ),
     ] = False,
+    legacy: Annotated[
+        bool,
+        typer.Option(
+            "--legacy",
+            help=(
+                "Use legacy structured annotation format (stringAnnos/longAnnos/"
+                "doubleAnnos) for compatibility with older leaderboard widgets "
+                "(default: false)"
+            ),
+        ),
+    ] = False,
+    skip_errors: Annotated[
+        bool,
+        typer.Option(
+            "--skip-errors",
+            help="Continue if an unknown ID error is encountered (default: false)",
+        ),
+    ] = False,
 ):
-    """Annotate one or more submission(s) with a JSON file."""
-    annotation.update_annotations_from_file(submission_id, str(json_file), verbose)
+    """Annotate one or more submission(s) with a JSON file.
+
+    When --legacy is set, also writes annotations in the legacy
+    stringAnnos/longAnnos/doubleAnnos format for compatibility with
+    older leaderboard widgets.
+    """
+    for submission_id in submission_ids:
+        try:
+            if legacy:
+                annotation.update_legacy_annotations_from_file(
+                    submission_id, str(json_file), verbose=verbose
+                )
+            annotation.update_annotations_from_file(
+                submission_id, str(json_file), verbose
+            )
+        except UnknownSynapseID as err:
+            if skip_errors:
+                print(f"Unknown submission ID: {submission_id} - skipping...")
+                continue
+            sys.exit(err)
 
 
 @app.command()

--- a/cnb_tools/modules/annotation.py
+++ b/cnb_tools/modules/annotation.py
@@ -107,17 +107,81 @@ def update_annotations(
         print(json.dumps(status.submissionAnnotations, indent=2))
 
     return status
+
+
+def _submission_annotations_to_dict(annotations: dict, is_private: bool = True) -> dict:
+    """Convert legacy submission status annotations to a flat dictionary."""
+    return {
+        annot["key"]: annot["value"]
+        for annotation_type in annotations
+        for annot in annotations[annotation_type]
+        if annotation_type not in ["scopeId", "objectId"]
+        and annot["isPrivate"] == is_private
+    }
+
+
+def update_legacy_annotations(
+    submission_id: int,
+    new_annotations: dict[str, str | int | float | bool],
+    is_private: bool = True,
+    verbose: bool = False,
+) -> SubmissionStatus:
+    """Update submission annotations using the legacy structured format.
+
+    Note: Backwards Compatibility
+      This function is intended for challenges that use older leaderboard
+      widgets requiring the legacy ``stringAnnos`` / ``longAnnos`` /
+      ``doubleAnnos`` annotation format. Prefer :func:`update_annotations`
+      for new challenges.
+
+    Args:
+      submission_id: ID of the submission.
+      new_annotations: Dictionary of annotations to add or update.
+      is_private: If True (default), annotations are stored as private and
+        will not be visible on public leaderboards.
+      verbose: If True, print the updated annotations after storing.
+
+    Returns:
+      Updated ``SubmissionStatus`` object.
+    """
+    syn = get_synapse_client()
     status = get_submission_status(submission_id)
-    if status.submission_annotations is None:
-        status.submission_annotations = {}
-    status.submission_annotations.update(new_annotations)
-    status = status.store()
+
+    existing_annots = status.get("annotations", {})
+    private_annotations = _submission_annotations_to_dict(
+        existing_annots, is_private=True
+    )
+    public_annotations = _submission_annotations_to_dict(
+        existing_annots, is_private=False
+    )
+
+    if is_private:
+        private_annotations.update(new_annotations)
+    else:
+        public_annotations.update(new_annotations)
+
+    priv = to_submission_status_annotations(private_annotations, is_private=True)
+    pub = to_submission_status_annotations(public_annotations, is_private=False)
+
+    combined = {"stringAnnos": [], "longAnnos": [], "doubleAnnos": []}
+    for annot_type in ["stringAnnos", "longAnnos", "doubleAnnos"]:
+        priv_list = priv.get(annot_type)
+        pub_list = pub.get(annot_type)
+        if priv_list:
+            combined[annot_type].extend(priv_list)
+        if pub_list:
+            combined[annot_type].extend(pub_list)
+        if not priv_list and not pub_list:
+            combined.pop(annot_type)
+
+    status["annotations"] = combined
+    status = syn.store(status)
 
     print(f"Submission ID {submission_id} annotations updated.")
 
     if verbose:
         print("Annotations:")
-        print(json.dumps(status.submission_annotations, indent=2))
+        print(json.dumps(status.get("annotations"), indent=2))
 
     return status
 
@@ -156,6 +220,47 @@ def update_annotations_from_file(
     )
 
 
+def update_legacy_annotations_from_file(
+    submission_id: int,
+    annots_file: str,
+    is_private: bool = True,
+    verbose: bool = False,
+) -> SubmissionStatus:
+    """Update legacy submission annotations from a JSON file.
+
+    Note: Backwards Compatibility
+      Use this for challenges that require the legacy ``stringAnnos`` /
+      ``longAnnos`` / ``doubleAnnos`` annotation format. Prefer
+      :func:`update_annotations_from_file` for new challenges.
+
+    Args:
+      submission_id: ID of the submission.
+      annots_file: Path to a JSON file containing annotation key-value pairs.
+      is_private: If True (default), annotations are stored as private.
+      verbose: If True, print the updated annotations after storing.
+
+    Returns:
+      Updated ``SubmissionStatus`` object.
+    """
+    with open(annots_file, encoding="utf-8") as f:
+        new_annotations = json.load(f)
+
+    # Filter annotations with null and empty-list values
+    new_annotations = {
+        key: value for key, value in new_annotations.items() if value not in [None, []]
+    }
+
+    return with_retry(
+        lambda: update_legacy_annotations(
+            submission_id, new_annotations, is_private, verbose
+        ),
+        wait=3,
+        retries=10,
+        retry_status_codes=[412, 429, 500, 502, 503, 504],
+        verbose=True,
+    )
+
+
 def update_submission_status(submission_id: int, new_status: str) -> SubmissionStatus:
     """Update the status of a submission.
 
@@ -171,9 +276,14 @@ def update_submission_status(submission_id: int, new_status: str) -> SubmissionS
     Returns:
       Updated ``SubmissionStatus`` object.
     """
+    # TODO: Revert to OOP approach once synapseclient bug is fixed.
+    # status = get_submission_status(submission_id)
+    # status.status = new_status
+    # status = status.store()
+    syn = get_synapse_client()
     status = get_submission_status(submission_id)
     status.status = new_status
-    status = status.store()
+    status = syn.store(status)
 
     print(f"Updated submission ID {submission_id} to status: {new_status}")
 

--- a/cnb_tools/modules/annotation.py
+++ b/cnb_tools/modules/annotation.py
@@ -6,9 +6,14 @@ submission annotations in Synapse challenges.
 
 import json
 
+# TODO: Revert to OOP approach once synapseclient bug is fixed.
+# See: https://github.com/Sage-Bionetworks-Challenges/cnb-tools/issues/43
+# from synapseclient.models import SubmissionStatus
+
+from synapseclient import SubmissionStatus
+from synapseclient.annotations import to_submission_status_annotations
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.core.retry import with_retry
-from synapseclient.models import SubmissionStatus
 
 from cnb_tools.modules.client import get_synapse_client, UnknownSynapseID
 
@@ -29,9 +34,12 @@ def get_submission_status(submission_id: int) -> SubmissionStatus:
     Raises:
       UnknownSynapseID: If the submission ID is invalid.
     """
-    get_synapse_client()  # ensure authentication
+    # TODO: Revert to OOP approach once synapseclient bug is fixed.
+    # get_synapse_client()  # ensure authentication
+    # return SubmissionStatus(id=str(submission_id)).get()
+    syn = get_synapse_client()
     try:
-        return SubmissionStatus(id=str(submission_id)).get()
+        return syn.getSubmissionStatus(submission_id)
     except SynapseHTTPError as err:
         raise UnknownSynapseID(
             f"⛔ {err.response.json().get('reason')}. " "Check the ID and try again."
@@ -53,7 +61,9 @@ def format_annotations(submission_status: SubmissionStatus) -> str:
     """
     output = f"     Status: {submission_status.status}\n"
     output += "Annotations:\n"
-    output += json.dumps(submission_status.submission_annotations, indent=2)
+    # TODO: Revert to OOP approach once synapseclient bug is fixed.
+    # output += json.dumps(submission_status.submission_annotations, indent=2)
+    output += json.dumps(submission_status.submissionAnnotations, indent=2)
     return output
 
 
@@ -76,6 +86,27 @@ def update_annotations(
     Returns:
       Updated ``SubmissionStatus`` object.
     """
+    # TODO: Revert to OOP approach once synapseclient bug is fixed.
+    # status = get_submission_status(submission_id)
+    # status.submission_annotations = {
+    #     **(status.submission_annotations or {}),
+    #     **new_annotations,
+    # }
+    # status = status.store()
+    syn = get_synapse_client()
+    status = get_submission_status(submission_id)
+    status.submissionAnnotations.update(new_annotations)
+    status = syn.store(status)
+
+    print(f"Submission ID {submission_id} annotations updated.")
+
+    if verbose:
+        print("Annotations:")
+        # TODO: Revert to OOP approach once synapseclient bug is fixed.
+        # print(json.dumps(status.submission_annotations, indent=2))
+        print(json.dumps(status.submissionAnnotations, indent=2))
+
+    return status
     status = get_submission_status(submission_id)
     if status.submission_annotations is None:
         status.submission_annotations = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,13 +24,19 @@ def mock_syn():
     """Fixture for mocked Synapse client."""
     return MagicMock()
 
+# def mock_submission_status():
+#     """Fixture for mocked SubmissionStatus."""
+#     status = MagicMock(spec=ModelSubmissionStatus)
+#     status.status = "SCORED"
+#     status.submission_annotations = {"score": 0.95, "passed": True}
+#     return status
 
 @pytest.fixture
 def mock_submission_status():
-    """Fixture for mocked SubmissionStatus."""
-    status = MagicMock(spec=ModelSubmissionStatus)
+    """Fixture for mocked SubmissionStatus (legacy pre-OOP format)."""
+    status = MagicMock()
     status.status = "SCORED"
-    status.submission_annotations = {"score": 0.95, "passed": True}
+    status.submissionAnnotations = {"score": 0.95, "passed": True}
     return status
 
 

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -12,27 +12,26 @@ from cnb_tools.modules.client import UnknownSynapseID
 class TestGetSubmissionStatus:
     """Tests for get_submission_status function"""
 
-    @patch("cnb_tools.modules.annotation.SubmissionStatus")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_get_submission_status_success(
-        self, mock_get_client, MockStatus, mock_submission_status
+        self, mock_get_client, mock_syn, mock_submission_status
     ):
         """Test successfully getting submission status"""
-        MockStatus.return_value.get.return_value = mock_submission_status
+        mock_get_client.return_value = mock_syn
+        mock_syn.getSubmissionStatus.return_value = mock_submission_status
 
         result = annotation.get_submission_status(12345)
 
-        MockStatus.assert_called_once_with(id="12345")
-        MockStatus.return_value.get.assert_called_once()
+        mock_syn.getSubmissionStatus.assert_called_once_with(12345)
         assert result == mock_submission_status
 
-    @patch("cnb_tools.modules.annotation.SubmissionStatus")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_get_submission_status_invalid_id(self, mock_get_client, MockStatus):
+    def test_get_submission_status_invalid_id(self, mock_get_client, mock_syn):
         """Test error handling for invalid submission ID"""
+        mock_get_client.return_value = mock_syn
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Submission not found"}
-        MockStatus.return_value.get.side_effect = SynapseHTTPError(
+        mock_syn.getSubmissionStatus.side_effect = SynapseHTTPError(
             response=mock_response
         )
 
@@ -45,32 +44,36 @@ class TestUpdateAnnotations:
     """Tests for update_annotations function"""
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_annotations_success(
-        self, mock_get_status, mock_submission_status, capsys
+        self, mock_get_client, mock_get_status, mock_syn, mock_submission_status, capsys
     ):
         """Test successfully updating annotations"""
+        mock_get_client.return_value = mock_syn
         mock_get_status.return_value = mock_submission_status
-        mock_submission_status.submission_annotations = {}
-        mock_submission_status.store.return_value = mock_submission_status
+        mock_submission_status.submissionAnnotations = {}
+        mock_syn.store.return_value = mock_submission_status
 
         new_annots = {"new_field": "value"}
         result = annotation.update_annotations(12345, new_annots, verbose=False)
 
-        assert mock_submission_status.submission_annotations == new_annots
-        mock_submission_status.store.assert_called_once()
+        assert mock_submission_status.submissionAnnotations == new_annots
+        mock_syn.store.assert_called_once_with(mock_submission_status)
 
         captured = capsys.readouterr()
         assert "Submission ID 12345 annotations updated" in captured.out
         assert result == mock_submission_status
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_annotations_verbose(
-        self, mock_get_status, mock_submission_status, capsys
+        self, mock_get_client, mock_get_status, mock_syn, mock_submission_status, capsys
     ):
         """Test updating annotations with verbose output"""
+        mock_get_client.return_value = mock_syn
         mock_get_status.return_value = mock_submission_status
-        mock_submission_status.submission_annotations = {"score": 0.95, "passed": True}
-        mock_submission_status.store.return_value = mock_submission_status
+        mock_submission_status.submissionAnnotations = {"score": 0.95, "passed": True}
+        mock_syn.store.return_value = mock_submission_status
 
         annotation.update_annotations(12345, {"test": "value"}, verbose=True)
 
@@ -109,17 +112,19 @@ class TestUpdateSubmissionStatus:
     """Tests for update_submission_status function"""
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_submission_status(
-        self, mock_get_status, mock_submission_status, capsys
+        self, mock_get_client, mock_get_status, mock_syn, mock_submission_status, capsys
     ):
         """Test updating submission status"""
+        mock_get_client.return_value = mock_syn
         mock_get_status.return_value = mock_submission_status
-        mock_submission_status.store.return_value = mock_submission_status
+        mock_syn.store.return_value = mock_submission_status
 
         result = annotation.update_submission_status(12345, "ACCEPTED")
 
         assert mock_submission_status.status == "ACCEPTED"
-        mock_submission_status.store.assert_called_once()
+        mock_syn.store.assert_called_once_with(mock_submission_status)
 
         captured = capsys.readouterr()
         assert "Updated submission ID 12345 to status: ACCEPTED" in captured.out

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -129,3 +129,153 @@ class TestUpdateSubmissionStatus:
         captured = capsys.readouterr()
         assert "Updated submission ID 12345 to status: ACCEPTED" in captured.out
         assert result == mock_submission_status
+
+
+class TestSubmissionAnnotationsToDict:
+    """Tests for _submission_annotations_to_dict helper"""
+
+    def test_returns_private_annotations(self):
+        """Test extracting private annotations"""
+        annotations = {
+            "stringAnnos": [
+                {"key": "score", "value": "0.95", "isPrivate": True},
+                {"key": "public_key", "value": "pub_val", "isPrivate": False},
+            ]
+        }
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=True
+        )
+        assert result == {"score": "0.95"}
+
+    def test_returns_public_annotations(self):
+        """Test extracting public annotations"""
+        annotations = {
+            "stringAnnos": [
+                {"key": "score", "value": "0.95", "isPrivate": True},
+                {"key": "public_key", "value": "pub_val", "isPrivate": False},
+            ]
+        }
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=False
+        )
+        assert result == {"public_key": "pub_val"}
+
+    def test_skips_scope_and_object_id(self):
+        """Test that scopeId and objectId keys are excluded"""
+        annotations = {
+            "scopeId": [{"key": "scopeId", "value": "12345", "isPrivate": True}],
+            "objectId": [{"key": "objectId", "value": "67890", "isPrivate": True}],
+            "stringAnnos": [{"key": "score", "value": "0.95", "isPrivate": True}],
+        }
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=True
+        )
+        assert result == {"score": "0.95"}
+
+    def test_empty_annotations(self):
+        """Test that an empty dict is returned for empty input"""
+        result = annotation._submission_annotations_to_dict({})
+        assert result == {}
+
+    def test_multiple_annotation_types(self):
+        """Test extracting annotations across stringAnnos, longAnnos, doubleAnnos"""
+        annotations = {
+            "stringAnnos": [{"key": "status", "value": "pass", "isPrivate": True}],
+            "longAnnos": [{"key": "rank", "value": 1, "isPrivate": True}],
+            "doubleAnnos": [{"key": "score", "value": 0.95, "isPrivate": True}],
+        }
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=True
+        )
+        assert result == {"status": "pass", "rank": 1, "score": 0.95}
+
+
+class TestUpdateLegacyAnnotations:
+    """Tests for update_legacy_annotations function"""
+
+    @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
+    @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
+    def test_update_private_annotations(
+        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn, capsys
+    ):
+        """Test storing annotations as private (default)"""
+        mock_get_client.return_value = mock_syn
+        mock_status = MagicMock()
+        mock_status.get.return_value = {}
+        mock_get_status.return_value = mock_status
+        mock_to_annots.return_value = {}
+        mock_syn.store.return_value = mock_status
+
+        result = annotation.update_legacy_annotations(12345, {"score": "0.95"})
+
+        mock_syn.store.assert_called_once_with(mock_status)
+        captured = capsys.readouterr()
+        assert "Submission ID 12345 annotations updated" in captured.out
+        assert result == mock_status
+
+    @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
+    @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
+    def test_update_public_annotations(
+        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn
+    ):
+        """Test storing annotations as public"""
+        mock_get_client.return_value = mock_syn
+        mock_status = MagicMock()
+        mock_status.get.return_value = {}
+        mock_get_status.return_value = mock_status
+        mock_to_annots.return_value = {}
+        mock_syn.store.return_value = mock_status
+
+        annotation.update_legacy_annotations(12345, {"score": "0.95"}, is_private=False)
+
+        # Called once for private annotations, once for public
+        assert mock_to_annots.call_count == 2
+        calls = mock_to_annots.call_args_list
+        assert calls[0][1]["is_private"] is True
+        assert calls[1][1]["is_private"] is False
+
+    @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
+    @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
+    def test_update_legacy_annotations_verbose(
+        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn, capsys
+    ):
+        """Test verbose output includes annotations"""
+        mock_get_client.return_value = mock_syn
+        mock_status = MagicMock()
+        mock_status.get.return_value = {}
+        mock_get_status.return_value = mock_status
+        mock_to_annots.return_value = {}
+        mock_syn.store.return_value = mock_status
+
+        annotation.update_legacy_annotations(12345, {"score": "0.95"}, verbose=True)
+
+        captured = capsys.readouterr()
+        assert "Annotations:" in captured.out
+
+    @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
+    @patch("cnb_tools.modules.annotation.get_submission_status")
+    @patch("cnb_tools.modules.annotation.get_synapse_client")
+    def test_merges_with_existing_annotations(
+        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn
+    ):
+        """Test that new annotations are merged with existing ones"""
+        mock_get_client.return_value = mock_syn
+        mock_status = MagicMock()
+        existing = {
+            "stringAnnos": [{"key": "old_key", "value": "old_val", "isPrivate": True}]
+        }
+        mock_status.get.return_value = existing
+        mock_get_status.return_value = mock_status
+        mock_to_annots.return_value = {}
+        mock_syn.store.return_value = mock_status
+
+        annotation.update_legacy_annotations(12345, {"new_key": "new_val"})
+
+        # The first call to to_submission_status_annotations should contain
+        # both the old and new private annotations
+        first_call_dict = mock_to_annots.call_args_list[0][0][0]
+        assert "old_key" in first_call_dict
+        assert "new_key" in first_call_dict


### PR DESCRIPTION
Fixes #43 

## Changelog
- Revert to pre-OOP methods for updating annotations (for now)
- Add feature for adding/updating legacy submission annotations too (for use cases when the old leaderboard widgets are used instead of SubmissionViews)
- Update tests
