### PR TITLE
Feat/34

### DIFF
--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -65,6 +65,7 @@ from cnb_tools.modules.submission import (
     get_submission,
     delete_submission,
     download_submission,
+    batch_download_submissions,
     get_submitter_name,
     get_challenge_name,
     print_submission_info,
@@ -116,6 +117,7 @@ __all__ = [
     "print_submission_info",
     "get_submission_contributors",
     "get_contributors",
+    "batch_download_submissions",
     "__version__",
 ]
 

--- a/cnb_tools/commands/submission_cli.py
+++ b/cnb_tools/commands/submission_cli.py
@@ -202,6 +202,37 @@ def get_contributors(
 
 
 @app.command()
+def batch_download(
+    evaluation_id: Annotated[int, typer.Argument(help="Evaluation queue ID")],
+    dest: Annotated[
+        Path,
+        typer.Option(
+            "--dest",
+            "-d",
+            help="Root destination directory (default: current directory)",
+        ),
+    ] = ".",
+    status: Annotated[
+        str | None,
+        typer.Option(
+            "--status",
+            "-s",
+            help=(
+                "Only download submissions with this status "
+                "(e.g. SCORED, ACCEPTED). Downloads all statuses if omitted."
+            ),
+        ),
+    ] = None,
+):
+    """Batch-download all submission files from an evaluation queue.
+
+    Files are saved under DEST/<submitter>/<submission_id><ext>.
+    Docker submissions are skipped.
+    """
+    submission.batch_download_submissions(evaluation_id, str(dest), status)
+
+
+@app.command()
 def reset(
     submission_ids: Annotated[
         list[int], typer.Argument(help="One or more submission ID(s)")

--- a/cnb_tools/modules/submission.py
+++ b/cnb_tools/modules/submission.py
@@ -206,3 +206,58 @@ def get_contributors(
             if bundle.submission and bundle.submission.contributors:
                 all_contributors.update(bundle.submission.contributors)
     return all_contributors
+
+
+def batch_download_submissions(
+    evaluation_id: int,
+    dest: str = ".",
+    status: str | None = None,
+) -> None:
+    """Download all submission files from an evaluation queue.
+
+    Files are organized into subdirectories named after each submitter.
+    Each file is renamed to ``<submission_id><original_extension>`` so
+    organizers can trace a file back to its submission. Docker submissions
+    are skipped with an informational message.
+
+    Tip: Example Use Case
+      Download every prediction file submitted to a challenge queue at
+      the end of the challenge for offline analysis or archival.
+
+    Args:
+      evaluation_id: Evaluation queue ID.
+      dest: Root destination directory (default: current directory).
+        Subdirectories per submitter are created automatically.
+      status: Only download submissions in this status (e.g.
+        ``"SCORED"``, ``"ACCEPTED"``). If ``None``, all submissions are
+        downloaded regardless of status.
+    """
+    syn = get_synapse_client()
+    base = Path(dest)
+    count = 0
+
+    for sub in syn.getSubmissions(evaluation_id, status=status):
+        submission_id = sub["id"]
+        submitter_id = sub.get("teamId") or sub.get("userId")
+        submitter_name = get_submitter_name(int(submitter_id)).replace(" ", "_")
+
+        download_dir = base / submitter_name
+        download_dir.mkdir(parents=True, exist_ok=True)
+
+        if sub.get("dockerDigest"):
+            print(
+                f"Skipping submission {submission_id} "
+                f"(Docker image — use `cnb-tools submission download` to get pull command)"
+            )
+            continue
+
+        downloaded = syn.getSubmission(
+            submission_id, downloadLocation=str(download_dir)
+        )
+        original = Path(downloaded.filePath)
+        renamed = download_dir / f"{submission_id}{original.suffix}"
+        original.rename(renamed)
+        print(f"Downloaded submission {submission_id} → {renamed}")
+        count += 1
+
+    print(f"\nDone. {count} file(s) downloaded to: {Path(dest).resolve()}")

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -224,3 +224,110 @@ class TestGetSubmissionContributors:
         result = submission.get_submission_contributors(12345)
 
         assert result == []
+
+
+class TestBatchDownloadSubmissions:
+    """Tests for batch_download_submissions function"""
+
+    @patch("cnb_tools.modules.submission.get_submitter_name")
+    @patch("cnb_tools.modules.submission.get_synapse_client")
+    def test_downloads_file_submissions(
+        self, mock_get_client, mock_get_submitter, mock_syn, tmp_path, capsys
+    ):
+        """Test that file submissions are downloaded and renamed"""
+        mock_get_client.return_value = mock_syn
+        mock_get_submitter.return_value = "Test Team"
+
+        sub = {"id": "12345", "teamId": "111", "userId": None, "dockerDigest": None}
+        mock_syn.getSubmissions.return_value = [sub]
+
+        # Create a real file that Path.rename can act on
+        original_file = tmp_path / "predictions.csv"
+        original_file.touch()
+        downloaded = MagicMock()
+        downloaded.filePath = str(original_file)
+        mock_syn.getSubmission.return_value = downloaded
+
+        submission.batch_download_submissions(98765, dest=str(tmp_path))
+
+        mock_syn.getSubmissions.assert_called_once_with(98765, status=None)
+        mock_syn.getSubmission.assert_called_once_with(
+            "12345", downloadLocation=str(tmp_path / "Test_Team")
+        )
+
+        captured = capsys.readouterr()
+        assert "Downloaded submission 12345" in captured.out
+        assert "1 file(s) downloaded" in captured.out
+
+    @patch("cnb_tools.modules.submission.get_submitter_name")
+    @patch("cnb_tools.modules.submission.get_synapse_client")
+    def test_skips_docker_submissions(
+        self, mock_get_client, mock_get_submitter, mock_syn, tmp_path, capsys
+    ):
+        """Test that Docker submissions are skipped"""
+        mock_get_client.return_value = mock_syn
+        mock_get_submitter.return_value = "Test Team"
+
+        sub = {
+            "id": "12345",
+            "teamId": "111",
+            "userId": None,
+            "dockerDigest": "sha256:abc123",
+        }
+        mock_syn.getSubmissions.return_value = [sub]
+
+        submission.batch_download_submissions(98765, dest=str(tmp_path))
+
+        mock_syn.getSubmission.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "Skipping submission 12345" in captured.out
+        assert "0 file(s) downloaded" in captured.out
+
+    @patch("cnb_tools.modules.submission.get_submitter_name")
+    @patch("cnb_tools.modules.submission.get_synapse_client")
+    def test_filters_by_status(
+        self, mock_get_client, mock_get_submitter, mock_syn, tmp_path
+    ):
+        """Test that the status filter is passed to getSubmissions"""
+        mock_get_client.return_value = mock_syn
+        mock_syn.getSubmissions.return_value = []
+
+        submission.batch_download_submissions(
+            98765, dest=str(tmp_path), status="SCORED"
+        )
+
+        mock_syn.getSubmissions.assert_called_once_with(98765, status="SCORED")
+
+    @patch("cnb_tools.modules.submission.get_submitter_name")
+    @patch("cnb_tools.modules.submission.get_synapse_client")
+    def test_organizes_by_submitter(
+        self, mock_get_client, mock_get_submitter, mock_syn, tmp_path, capsys
+    ):
+        """Test that files from different submitters go into separate directories"""
+        mock_get_client.return_value = mock_syn
+
+        subs = [
+            {"id": "111", "teamId": "11", "userId": None, "dockerDigest": None},
+            {"id": "222", "teamId": "22", "userId": None, "dockerDigest": None},
+        ]
+        mock_syn.getSubmissions.return_value = subs
+        mock_get_submitter.side_effect = ["Team A", "Team B"]
+
+        for sub_id in ["111", "222"]:
+            f = tmp_path / f"{sub_id}.csv"
+            f.touch()
+
+        def fake_get_submission(sid, downloadLocation):
+            dl = MagicMock()
+            dl.filePath = str(tmp_path / f"{sid}.csv")
+            return dl
+
+        mock_syn.getSubmission.side_effect = fake_get_submission
+
+        submission.batch_download_submissions(98765, dest=str(tmp_path))
+
+        captured = capsys.readouterr()
+        assert "Team_A" in captured.out
+        assert "Team_B" in captured.out
+        assert "2 file(s) downloaded" in captured.out


### PR DESCRIPTION
Fixes #34 

## Changelog
- Add feature to download all prediction files from a given evaluation queue into a destination folder

