### PR TITLE
[fix] bump minimum typer version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = [
-    "typer>=0.9.0",
+    "typer>=0.12.0",
     "synapseclient>=4.7.0",
     "click>=8.0.0,<8.2.0",
     "pandas>=2.0.3",


### PR DESCRIPTION
Fix compatibility issue with typer 0.9.4 and the union syntax:

```python
RuntimeError: Type not yet supported: str | None
```

Upgrading to at least typer 0.12 will resolve the issue.