### PR TITLE
[chore] Revert SubmissionStatus to OOP approach

### DIFF
--- a/cnb_tools/modules/annotation.py
+++ b/cnb_tools/modules/annotation.py
@@ -99,8 +99,7 @@ def _submission_annotations_to_dict(annotations: dict, is_private: bool = True) 
         annot["key"]: annot["value"]
         for annotation_type in annotations
         for annot in annotations[annotation_type]
-        if annotation_type not in ["scopeId", "objectId"]
-        and annot["isPrivate"] == is_private
+        if annotation_type not in ["scopeId", "objectId"] and annot["isPrivate"] == is_private
     }
 
 
@@ -132,12 +131,8 @@ def update_legacy_annotations(
     status = syn.getSubmissionStatus(submission_id)
 
     existing_annots = status.get("annotations", {})
-    private_annotations = _submission_annotations_to_dict(
-        existing_annots, is_private=True
-    )
-    public_annotations = _submission_annotations_to_dict(
-        existing_annots, is_private=False
-    )
+    private_annotations = _submission_annotations_to_dict(existing_annots, is_private=True)
+    public_annotations = _submission_annotations_to_dict(existing_annots, is_private=False)
 
     if is_private:
         private_annotations.update(new_annotations)
@@ -235,9 +230,7 @@ def update_legacy_annotations_from_file(
     }
 
     return with_retry(
-        lambda: update_legacy_annotations(
-            submission_id, new_annotations, is_private, verbose
-        ),
+        lambda: update_legacy_annotations(submission_id, new_annotations, is_private, verbose),
         wait=3,
         retries=10,
         retry_status_codes=[412, 429, 500, 502, 503, 504],

--- a/cnb_tools/modules/annotation.py
+++ b/cnb_tools/modules/annotation.py
@@ -6,13 +6,10 @@ submission annotations in Synapse challenges.
 
 import json
 
-# TODO: Revert to OOP approach once synapseclient bug is fixed.
-# See: https://github.com/Sage-Bionetworks-Challenges/cnb-tools/issues/43
-# from synapseclient.models import SubmissionStatus
-from synapseclient import SubmissionStatus
 from synapseclient.annotations import to_submission_status_annotations
 from synapseclient.core.exceptions import SynapseHTTPError
 from synapseclient.core.retry import with_retry
+from synapseclient.models import SubmissionStatus
 
 from cnb_tools.modules.client import UnknownSynapseID, get_synapse_client
 
@@ -33,12 +30,9 @@ def get_submission_status(submission_id: int) -> SubmissionStatus:
     Raises:
       UnknownSynapseID: If the submission ID is invalid.
     """
-    # TODO: Revert to OOP approach once synapseclient bug is fixed.
-    # get_synapse_client()  # ensure authentication
-    # return SubmissionStatus(id=str(submission_id)).get()
-    syn = get_synapse_client()
+    get_synapse_client()  # ensure authentication
     try:
-        return syn.getSubmissionStatus(submission_id)
+        return SubmissionStatus(id=str(submission_id)).get()
     except SynapseHTTPError as err:
         raise UnknownSynapseID(
             f"⛔ {err.response.json().get('reason')}. Check the ID and try again."
@@ -60,9 +54,7 @@ def format_annotations(submission_status: SubmissionStatus) -> str:
     """
     output = f"     Status: {submission_status.status}\n"
     output += "Annotations:\n"
-    # TODO: Revert to OOP approach once synapseclient bug is fixed.
-    # output += json.dumps(submission_status.submission_annotations, indent=2)
-    output += json.dumps(submission_status.submissionAnnotations, indent=2)
+    output += json.dumps(submission_status.submission_annotations, indent=2)
     return output
 
 
@@ -85,25 +77,18 @@ def update_annotations(
     Returns:
       Updated ``SubmissionStatus`` object.
     """
-    # TODO: Revert to OOP approach once synapseclient bug is fixed.
-    # status = get_submission_status(submission_id)
-    # status.submission_annotations = {
-    #     **(status.submission_annotations or {}),
-    #     **new_annotations,
-    # }
-    # status = status.store()
-    syn = get_synapse_client()
     status = get_submission_status(submission_id)
-    status.submissionAnnotations.update(new_annotations)
-    status = syn.store(status)
+    status.submission_annotations = {
+        **(status.submission_annotations or {}),
+        **new_annotations,
+    }
+    status = status.store()
 
     print(f"Submission ID {submission_id} annotations updated.")
 
     if verbose:
         print("Annotations:")
-        # TODO: Revert to OOP approach once synapseclient bug is fixed.
-        # print(json.dumps(status.submission_annotations, indent=2))
-        print(json.dumps(status.submissionAnnotations, indent=2))
+        print(json.dumps(status.submission_annotations, indent=2))
 
     return status
 
@@ -114,7 +99,8 @@ def _submission_annotations_to_dict(annotations: dict, is_private: bool = True) 
         annot["key"]: annot["value"]
         for annotation_type in annotations
         for annot in annotations[annotation_type]
-        if annotation_type not in ["scopeId", "objectId"] and annot["isPrivate"] == is_private
+        if annotation_type not in ["scopeId", "objectId"]
+        and annot["isPrivate"] == is_private
     }
 
 
@@ -143,11 +129,15 @@ def update_legacy_annotations(
       Updated ``SubmissionStatus`` object.
     """
     syn = get_synapse_client()
-    status = get_submission_status(submission_id)
+    status = syn.getSubmissionStatus(submission_id)
 
     existing_annots = status.get("annotations", {})
-    private_annotations = _submission_annotations_to_dict(existing_annots, is_private=True)
-    public_annotations = _submission_annotations_to_dict(existing_annots, is_private=False)
+    private_annotations = _submission_annotations_to_dict(
+        existing_annots, is_private=True
+    )
+    public_annotations = _submission_annotations_to_dict(
+        existing_annots, is_private=False
+    )
 
     if is_private:
         private_annotations.update(new_annotations)
@@ -245,7 +235,9 @@ def update_legacy_annotations_from_file(
     }
 
     return with_retry(
-        lambda: update_legacy_annotations(submission_id, new_annotations, is_private, verbose),
+        lambda: update_legacy_annotations(
+            submission_id, new_annotations, is_private, verbose
+        ),
         wait=3,
         retries=10,
         retry_status_codes=[412, 429, 500, 502, 503, 504],
@@ -268,14 +260,9 @@ def update_submission_status(submission_id: int, new_status: str) -> SubmissionS
     Returns:
       Updated ``SubmissionStatus`` object.
     """
-    # TODO: Revert to OOP approach once synapseclient bug is fixed.
-    # status = get_submission_status(submission_id)
-    # status.status = new_status
-    # status = status.store()
-    syn = get_synapse_client()
     status = get_submission_status(submission_id)
     status.status = new_status
-    status = syn.store(status)
+    status = status.store()
 
     print(f"Updated submission ID {submission_id} to status: {new_status}")
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,9 @@ from synapseclient.models import (
 from synapseclient.models import (
     Submission as ModelSubmission,
 )
+from synapseclient.models import (
+    SubmissionStatus as ModelSubmissionStatus,
+)
 
 
 def pytest_configure(config):
@@ -36,10 +39,10 @@ def mock_syn():
 
 @pytest.fixture
 def mock_submission_status():
-    """Fixture for mocked SubmissionStatus (legacy pre-OOP format)."""
-    status = MagicMock()
+    """Fixture for mocked SubmissionStatus (OOP model)."""
+    status = MagicMock(spec=ModelSubmissionStatus)
     status.status = "SCORED"
-    status.submissionAnnotations = {"score": 0.95, "passed": True}
+    status.submission_annotations = {"score": 0.95, "passed": True}
     return status
 
 

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -12,24 +12,33 @@ from cnb_tools.modules.client import UnknownSynapseID
 class TestGetSubmissionStatus:
     """Tests for get_submission_status function"""
 
+    @patch("cnb_tools.modules.annotation.SubmissionStatus")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_get_submission_status_success(self, mock_get_client, mock_syn, mock_submission_status):
+    def test_get_submission_status_success(
+        self, mock_get_client, mock_status_class, mock_syn, mock_submission_status
+    ):
         """Test successfully getting submission status"""
         mock_get_client.return_value = mock_syn
-        mock_syn.getSubmissionStatus.return_value = mock_submission_status
+        mock_status_class.return_value.get.return_value = mock_submission_status
 
         result = annotation.get_submission_status(12345)
 
-        mock_syn.getSubmissionStatus.assert_called_once_with(12345)
+        mock_status_class.assert_called_once_with(id="12345")
+        mock_status_class.return_value.get.assert_called_once()
         assert result == mock_submission_status
 
+    @patch("cnb_tools.modules.annotation.SubmissionStatus")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_get_submission_status_invalid_id(self, mock_get_client, mock_syn):
+    def test_get_submission_status_invalid_id(
+        self, mock_get_client, mock_status_class, mock_syn
+    ):
         """Test error handling for invalid submission ID"""
         mock_get_client.return_value = mock_syn
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Submission not found"}
-        mock_syn.getSubmissionStatus.side_effect = SynapseHTTPError(response=mock_response)
+        mock_status_class.return_value.get.side_effect = SynapseHTTPError(
+            response=mock_response
+        )
 
         with pytest.raises(UnknownSynapseID) as exc_info:
             annotation.get_submission_status(99999)
@@ -40,36 +49,32 @@ class TestUpdateAnnotations:
     """Tests for update_annotations function"""
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
-    @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_annotations_success(
-        self, mock_get_client, mock_get_status, mock_syn, mock_submission_status, capsys
+        self, mock_get_status, mock_submission_status, capsys
     ):
         """Test successfully updating annotations"""
-        mock_get_client.return_value = mock_syn
         mock_get_status.return_value = mock_submission_status
-        mock_submission_status.submissionAnnotations = {}
-        mock_syn.store.return_value = mock_submission_status
+        mock_submission_status.submission_annotations = {}
+        mock_submission_status.store.return_value = mock_submission_status
 
         new_annots = {"new_field": "value"}
         result = annotation.update_annotations(12345, new_annots, verbose=False)
 
-        assert mock_submission_status.submissionAnnotations == new_annots
-        mock_syn.store.assert_called_once_with(mock_submission_status)
+        assert mock_submission_status.submission_annotations == new_annots
+        mock_submission_status.store.assert_called_once()
 
         captured = capsys.readouterr()
         assert "Submission ID 12345 annotations updated" in captured.out
         assert result == mock_submission_status
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
-    @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_annotations_verbose(
-        self, mock_get_client, mock_get_status, mock_syn, mock_submission_status, capsys
+        self, mock_get_status, mock_submission_status, capsys
     ):
         """Test updating annotations with verbose output"""
-        mock_get_client.return_value = mock_syn
         mock_get_status.return_value = mock_submission_status
-        mock_submission_status.submissionAnnotations = {"score": 0.95, "passed": True}
-        mock_syn.store.return_value = mock_submission_status
+        mock_submission_status.submission_annotations = {"score": 0.95, "passed": True}
+        mock_submission_status.store.return_value = mock_submission_status
 
         annotation.update_annotations(12345, {"test": "value"}, verbose=True)
 
@@ -108,19 +113,17 @@ class TestUpdateSubmissionStatus:
     """Tests for update_submission_status function"""
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
-    @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_submission_status(
-        self, mock_get_client, mock_get_status, mock_syn, mock_submission_status, capsys
+        self, mock_get_status, mock_submission_status, capsys
     ):
         """Test updating submission status"""
-        mock_get_client.return_value = mock_syn
         mock_get_status.return_value = mock_submission_status
-        mock_syn.store.return_value = mock_submission_status
+        mock_submission_status.store.return_value = mock_submission_status
 
         result = annotation.update_submission_status(12345, "ACCEPTED")
 
         assert mock_submission_status.status == "ACCEPTED"
-        mock_syn.store.assert_called_once_with(mock_submission_status)
+        mock_submission_status.store.assert_called_once()
 
         captured = capsys.readouterr()
         assert "Updated submission ID 12345 to status: ACCEPTED" in captured.out
@@ -138,7 +141,9 @@ class TestSubmissionAnnotationsToDict:
                 {"key": "public_key", "value": "pub_val", "isPrivate": False},
             ]
         }
-        result = annotation._submission_annotations_to_dict(annotations, is_private=True)
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=True
+        )
         assert result == {"score": "0.95"}
 
     def test_returns_public_annotations(self):
@@ -149,7 +154,9 @@ class TestSubmissionAnnotationsToDict:
                 {"key": "public_key", "value": "pub_val", "isPrivate": False},
             ]
         }
-        result = annotation._submission_annotations_to_dict(annotations, is_private=False)
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=False
+        )
         assert result == {"public_key": "pub_val"}
 
     def test_skips_scope_and_object_id(self):
@@ -159,7 +166,9 @@ class TestSubmissionAnnotationsToDict:
             "objectId": [{"key": "objectId", "value": "67890", "isPrivate": True}],
             "stringAnnos": [{"key": "score", "value": "0.95", "isPrivate": True}],
         }
-        result = annotation._submission_annotations_to_dict(annotations, is_private=True)
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=True
+        )
         assert result == {"score": "0.95"}
 
     def test_empty_annotations(self):
@@ -174,7 +183,9 @@ class TestSubmissionAnnotationsToDict:
             "longAnnos": [{"key": "rank", "value": 1, "isPrivate": True}],
             "doubleAnnos": [{"key": "score", "value": 0.95, "isPrivate": True}],
         }
-        result = annotation._submission_annotations_to_dict(annotations, is_private=True)
+        result = annotation._submission_annotations_to_dict(
+            annotations, is_private=True
+        )
         assert result == {"status": "pass", "rank": 1, "score": 0.95}
 
 
@@ -182,16 +193,15 @@ class TestUpdateLegacyAnnotations:
     """Tests for update_legacy_annotations function"""
 
     @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
-    @patch("cnb_tools.modules.annotation.get_submission_status")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_private_annotations(
-        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn, capsys
+        self, mock_get_client, mock_to_annots, mock_syn, capsys
     ):
         """Test storing annotations as private (default)"""
         mock_get_client.return_value = mock_syn
         mock_status = MagicMock()
         mock_status.get.return_value = {}
-        mock_get_status.return_value = mock_status
+        mock_syn.getSubmissionStatus.return_value = mock_status
         mock_to_annots.return_value = {}
         mock_syn.store.return_value = mock_status
 
@@ -203,16 +213,13 @@ class TestUpdateLegacyAnnotations:
         assert result == mock_status
 
     @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
-    @patch("cnb_tools.modules.annotation.get_submission_status")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_update_public_annotations(
-        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn
-    ):
+    def test_update_public_annotations(self, mock_get_client, mock_to_annots, mock_syn):
         """Test storing annotations as public"""
         mock_get_client.return_value = mock_syn
         mock_status = MagicMock()
         mock_status.get.return_value = {}
-        mock_get_status.return_value = mock_status
+        mock_syn.getSubmissionStatus.return_value = mock_status
         mock_to_annots.return_value = {}
         mock_syn.store.return_value = mock_status
 
@@ -225,16 +232,15 @@ class TestUpdateLegacyAnnotations:
         assert calls[1][1]["is_private"] is False
 
     @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
-    @patch("cnb_tools.modules.annotation.get_submission_status")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_update_legacy_annotations_verbose(
-        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn, capsys
+        self, mock_get_client, mock_to_annots, mock_syn, capsys
     ):
         """Test verbose output includes annotations"""
         mock_get_client.return_value = mock_syn
         mock_status = MagicMock()
         mock_status.get.return_value = {}
-        mock_get_status.return_value = mock_status
+        mock_syn.getSubmissionStatus.return_value = mock_status
         mock_to_annots.return_value = {}
         mock_syn.store.return_value = mock_status
 
@@ -244,17 +250,18 @@ class TestUpdateLegacyAnnotations:
         assert "Annotations:" in captured.out
 
     @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
-    @patch("cnb_tools.modules.annotation.get_submission_status")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
     def test_merges_with_existing_annotations(
-        self, mock_get_client, mock_get_status, mock_to_annots, mock_syn
+        self, mock_get_client, mock_to_annots, mock_syn
     ):
         """Test that new annotations are merged with existing ones"""
         mock_get_client.return_value = mock_syn
         mock_status = MagicMock()
-        existing = {"stringAnnos": [{"key": "old_key", "value": "old_val", "isPrivate": True}]}
+        existing = {
+            "stringAnnos": [{"key": "old_key", "value": "old_val", "isPrivate": True}]
+        }
         mock_status.get.return_value = existing
-        mock_get_status.return_value = mock_status
+        mock_syn.getSubmissionStatus.return_value = mock_status
         mock_to_annots.return_value = {}
         mock_syn.store.return_value = mock_status
 

--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -29,16 +29,12 @@ class TestGetSubmissionStatus:
 
     @patch("cnb_tools.modules.annotation.SubmissionStatus")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_get_submission_status_invalid_id(
-        self, mock_get_client, mock_status_class, mock_syn
-    ):
+    def test_get_submission_status_invalid_id(self, mock_get_client, mock_status_class, mock_syn):
         """Test error handling for invalid submission ID"""
         mock_get_client.return_value = mock_syn
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Submission not found"}
-        mock_status_class.return_value.get.side_effect = SynapseHTTPError(
-            response=mock_response
-        )
+        mock_status_class.return_value.get.side_effect = SynapseHTTPError(response=mock_response)
 
         with pytest.raises(UnknownSynapseID) as exc_info:
             annotation.get_submission_status(99999)
@@ -49,9 +45,7 @@ class TestUpdateAnnotations:
     """Tests for update_annotations function"""
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
-    def test_update_annotations_success(
-        self, mock_get_status, mock_submission_status, capsys
-    ):
+    def test_update_annotations_success(self, mock_get_status, mock_submission_status, capsys):
         """Test successfully updating annotations"""
         mock_get_status.return_value = mock_submission_status
         mock_submission_status.submission_annotations = {}
@@ -68,9 +62,7 @@ class TestUpdateAnnotations:
         assert result == mock_submission_status
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
-    def test_update_annotations_verbose(
-        self, mock_get_status, mock_submission_status, capsys
-    ):
+    def test_update_annotations_verbose(self, mock_get_status, mock_submission_status, capsys):
         """Test updating annotations with verbose output"""
         mock_get_status.return_value = mock_submission_status
         mock_submission_status.submission_annotations = {"score": 0.95, "passed": True}
@@ -113,9 +105,7 @@ class TestUpdateSubmissionStatus:
     """Tests for update_submission_status function"""
 
     @patch("cnb_tools.modules.annotation.get_submission_status")
-    def test_update_submission_status(
-        self, mock_get_status, mock_submission_status, capsys
-    ):
+    def test_update_submission_status(self, mock_get_status, mock_submission_status, capsys):
         """Test updating submission status"""
         mock_get_status.return_value = mock_submission_status
         mock_submission_status.store.return_value = mock_submission_status
@@ -141,9 +131,7 @@ class TestSubmissionAnnotationsToDict:
                 {"key": "public_key", "value": "pub_val", "isPrivate": False},
             ]
         }
-        result = annotation._submission_annotations_to_dict(
-            annotations, is_private=True
-        )
+        result = annotation._submission_annotations_to_dict(annotations, is_private=True)
         assert result == {"score": "0.95"}
 
     def test_returns_public_annotations(self):
@@ -154,9 +142,7 @@ class TestSubmissionAnnotationsToDict:
                 {"key": "public_key", "value": "pub_val", "isPrivate": False},
             ]
         }
-        result = annotation._submission_annotations_to_dict(
-            annotations, is_private=False
-        )
+        result = annotation._submission_annotations_to_dict(annotations, is_private=False)
         assert result == {"public_key": "pub_val"}
 
     def test_skips_scope_and_object_id(self):
@@ -166,9 +152,7 @@ class TestSubmissionAnnotationsToDict:
             "objectId": [{"key": "objectId", "value": "67890", "isPrivate": True}],
             "stringAnnos": [{"key": "score", "value": "0.95", "isPrivate": True}],
         }
-        result = annotation._submission_annotations_to_dict(
-            annotations, is_private=True
-        )
+        result = annotation._submission_annotations_to_dict(annotations, is_private=True)
         assert result == {"score": "0.95"}
 
     def test_empty_annotations(self):
@@ -183,9 +167,7 @@ class TestSubmissionAnnotationsToDict:
             "longAnnos": [{"key": "rank", "value": 1, "isPrivate": True}],
             "doubleAnnos": [{"key": "score", "value": 0.95, "isPrivate": True}],
         }
-        result = annotation._submission_annotations_to_dict(
-            annotations, is_private=True
-        )
+        result = annotation._submission_annotations_to_dict(annotations, is_private=True)
         assert result == {"status": "pass", "rank": 1, "score": 0.95}
 
 
@@ -194,9 +176,7 @@ class TestUpdateLegacyAnnotations:
 
     @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_update_private_annotations(
-        self, mock_get_client, mock_to_annots, mock_syn, capsys
-    ):
+    def test_update_private_annotations(self, mock_get_client, mock_to_annots, mock_syn, capsys):
         """Test storing annotations as private (default)"""
         mock_get_client.return_value = mock_syn
         mock_status = MagicMock()
@@ -251,15 +231,11 @@ class TestUpdateLegacyAnnotations:
 
     @patch("cnb_tools.modules.annotation.to_submission_status_annotations")
     @patch("cnb_tools.modules.annotation.get_synapse_client")
-    def test_merges_with_existing_annotations(
-        self, mock_get_client, mock_to_annots, mock_syn
-    ):
+    def test_merges_with_existing_annotations(self, mock_get_client, mock_to_annots, mock_syn):
         """Test that new annotations are merged with existing ones"""
         mock_get_client.return_value = mock_syn
         mock_status = MagicMock()
-        existing = {
-            "stringAnnos": [{"key": "old_key", "value": "old_val", "isPrivate": True}]
-        }
+        existing = {"stringAnnos": [{"key": "old_key", "value": "old_val", "isPrivate": True}]}
         mock_status.get.return_value = existing
         mock_syn.getSubmissionStatus.return_value = mock_status
         mock_to_annots.return_value = {}


### PR DESCRIPTION
The upstream bug with the `SubmissionStatus` model was fixed in synapseclient v4.11.0 (SYNPY-1590), so this PR reverts `annotation.py` back to the original approach.