### PR TITLE
[feat] Add new CLI group for analyzing challenges

### DIFF
--- a/cnb_tools/__init__.py
+++ b/cnb_tools/__init__.py
@@ -66,7 +66,6 @@ from cnb_tools.modules.queue import (
     create_evaluation_round,
     get_challenge_name_from_evaluation,
     get_evaluation,
-    get_evaluation_ids_by_project,
     get_evaluations_by_project,
 )
 from cnb_tools.modules.submission import (
@@ -114,7 +113,6 @@ __all__ = [
     "set_evaluation_permissions",
     # queue
     "get_evaluation",
-    "get_evaluation_ids_by_project",
     "get_challenge_name_from_evaluation",
     "create_evaluation",
     "create_evaluation_round",

--- a/cnb_tools/commands/challenge_cli.py
+++ b/cnb_tools/commands/challenge_cli.py
@@ -266,11 +266,12 @@ def stats(
     num_queues = len(evaluations)
 
     def _count_submissions(ev) -> int:
-        return sum(1 for _ in syn.getSubmissions(ev.id))
+        return syn.restGET(f"/evaluation/{ev.id}/submission/count")
 
     if evaluations:
         with ThreadPoolExecutor(max_workers=min(8, len(evaluations))) as pool:
-            num_submissions = sum(pool.map(_count_submissions, evaluations))
+            submissions_per_queue = list(pool.map(_count_submissions, evaluations))
+        num_submissions = sum(submissions_per_queue)
     else:
         num_submissions = 0
 

--- a/cnb_tools/commands/challenge_cli.py
+++ b/cnb_tools/commands/challenge_cli.py
@@ -74,18 +74,14 @@ def create(
 
 @app.command()
 def launch(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
 ):
     """Launch a challenge by making the project publicly viewable.
 
     Grants READ access to all authenticated Synapse users on the project
     and sets the project's Status annotation to 'Active'.
     """
-    permissions.set_entity_permissions(
-        project_id, _AUTHENTICATED_USERS, permission_level="view"
-    )
+    permissions.set_entity_permissions(project_id, _AUTHENTICATED_USERS, permission_level="view")
     permissions.set_entity_permissions(project_id, _PUBLIC, permission_level="view")
     syn = get_synapse_client()
     entity = syn.get(project_id)
@@ -117,9 +113,7 @@ def register(
 
 @app.command()
 def unregister(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
 ):
     """Unregister a Synapse project as a challenge.
 
@@ -136,9 +130,7 @@ def unregister(
 
 @app.command()
 def get(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -159,9 +151,7 @@ def get(
 
 @app.command()
 def teams(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -206,9 +196,7 @@ def teams(
 
 @app.command()
 def queues(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -231,9 +219,7 @@ def queues(
 
 @app.command()
 def close(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project to close")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project to close")],
 ):
     """Close a challenge.
 
@@ -248,9 +234,7 @@ def close(
 
 @app.command()
 def stats(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),

--- a/cnb_tools/commands/challenge_cli.py
+++ b/cnb_tools/commands/challenge_cli.py
@@ -274,16 +274,6 @@ def stats(
     else:
         num_submissions = 0
 
-    try:
-        forum = syn.restGET(f"/entity/{project_id}/forum")
-        thread_resp = syn.restGET(
-            f"/forum/{forum['id']}/threads",
-            params={"limit": 1, "filter": "NO_FILTER"},
-        )
-        num_threads: int | None = thread_resp.get("totalNumberOfResults", 0)
-    except Exception:
-        num_threads = None
-
     if as_json:
         result: dict = {
             "project_id": project_id,
@@ -291,12 +281,10 @@ def stats(
             "registered_teams": num_teams,
             "evaluation_queues": num_queues,
             "total_submissions": num_submissions,
-            "discussion_threads": num_threads,
         }
         typer.echo(json.dumps(result, indent=2))
     else:
-        typer.echo(f"Registered participants:  {num_participants}")
-        typer.echo(f"Registered teams:         {num_teams}")
-        typer.echo(f"Evaluation queues:        {num_queues}")
-        typer.echo(f"Total submissions:        {num_submissions}")
-        typer.echo(f"Discussion threads:       {num_threads if num_threads is not None else 'N/A'}")
+        typer.echo(f"Registered participants: {num_participants}")
+        typer.echo(f"Registered teams:        {num_teams}")
+        typer.echo(f"Evaluation queues:       {num_queues}")
+        typer.echo(f"Total submissions:       {num_submissions}")

--- a/cnb_tools/commands/challenge_cli.py
+++ b/cnb_tools/commands/challenge_cli.py
@@ -74,14 +74,18 @@ def create(
 
 @app.command()
 def launch(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
 ):
     """Launch a challenge by making the project publicly viewable.
 
     Grants READ access to all authenticated Synapse users on the project
     and sets the project's Status annotation to 'Active'.
     """
-    permissions.set_entity_permissions(project_id, _AUTHENTICATED_USERS, permission_level="view")
+    permissions.set_entity_permissions(
+        project_id, _AUTHENTICATED_USERS, permission_level="view"
+    )
     permissions.set_entity_permissions(project_id, _PUBLIC, permission_level="view")
     syn = get_synapse_client()
     entity = syn.get(project_id)
@@ -113,7 +117,9 @@ def register(
 
 @app.command()
 def unregister(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
 ):
     """Unregister a Synapse project as a challenge.
 
@@ -130,7 +136,9 @@ def unregister(
 
 @app.command()
 def get(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -151,7 +159,9 @@ def get(
 
 @app.command()
 def teams(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -196,7 +206,9 @@ def teams(
 
 @app.command()
 def queues(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -219,7 +231,9 @@ def queues(
 
 @app.command()
 def close(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project to close")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project to close")
+    ],
 ):
     """Close a challenge.
 
@@ -234,7 +248,9 @@ def close(
 
 @app.command()
 def stats(
-    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
     as_json: Annotated[
         bool,
         typer.Option("--json", help="Output raw JSON instead of formatted text"),
@@ -242,9 +258,8 @@ def stats(
 ):
     """Show basic statistics for a challenge.
 
-    Reports registered participants, registered teams, evaluation queues,
-    total submissions across all queues (fetched in parallel), and
-    discussion thread count.
+    Reports number of registered participants, registered teams, evaluation queues,
+    and total submissions across all queues.
     """
     syn = get_synapse_client()
 

--- a/cnb_tools/commands/summarize_cli.py
+++ b/cnb_tools/commands/summarize_cli.py
@@ -167,6 +167,10 @@ def submissions(
         bool,
         typer.Option("--weekly", help="Group by ISO week instead of day"),
     ] = False,
+    ignore_empty: Annotated[
+        bool,
+        typer.Option("--ignore-empty", help="Hide rows with zero counts"),
+    ] = False,
 ):
     """Show a histogram of submissions over time.
 
@@ -227,6 +231,8 @@ def submissions(
 
     for key in sorted_keys:
         count = counts[key]
+        if ignore_empty and count == 0:
+            continue
         filled = int(count / max_count * bar_width) if max_count > 0 else 0
         bar = "[green]" + "█" * filled + "[/green]"
         pct = f"{count / total * 100:.1f}"
@@ -238,6 +244,10 @@ def submissions(
 @app.command()
 def participants(
     project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    ignore_empty: Annotated[
+        bool,
+        typer.Option("--ignore-empty", help="Hide categories with zero participants"),
+    ] = False,
 ):
     """Show a breakdown of participants by organization type.
 
@@ -293,6 +303,8 @@ def participants(
 
     for category in _CATEGORY_ORDER:
         count = counts.get(category, 0)
+        if ignore_empty and count == 0:
+            continue
         color = _CATEGORY_COLORS[category]
         filled = int(count / max_count * bar_width) if count > 0 else 0
         bar = f"[{color}]" + "█" * filled + f"[/{color}]"
@@ -304,3 +316,68 @@ def participants(
         "[dim]Note: Categories are estimated using keyword matching on self-reported "
         "company and industry fields. Results may not be accurate.[/dim]\n"
     )
+
+
+@app.command()
+def queues(
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
+    ignore_empty: Annotated[
+        bool,
+        typer.Option("--ignore-empty", help="Hide queues with zero submissions"),
+    ] = False,
+):
+    """Show a breakdown of submissions per evaluation queue.
+
+    Fetches the submission count for each queue in parallel and prints a
+    bar chart sorted by queue name.
+    """
+    syn = get_synapse_client()
+    console = Console()
+
+    try:
+        evaluations = get_evaluations_by_project(project_id)
+    except UnknownSynapseID as err:
+        sys.exit(err)
+
+    if not evaluations:
+        typer.echo(f"No evaluation queues found for {project_id}.")
+        return
+
+    def _count(ev) -> tuple[str, str, int]:
+        return ev.id, ev.name or ev.id or "", syn.restGET(f"/evaluation/{ev.id}/submission/count")
+
+    with ThreadPoolExecutor(max_workers=min(8, len(evaluations))) as pool:
+        futures = {pool.submit(_count, ev): ev for ev in evaluations}
+        results = [future.result() for future in as_completed(futures)]
+
+    results.sort(key=lambda r: r[1])  # sort by name
+    if ignore_empty:
+        results = [r for r in results if r[2] > 0]
+    total = sum(r[2] for r in results)
+
+    if total == 0:
+        typer.echo("No submissions found.")
+        return
+
+    max_count = max(r[2] for r in results)
+    bar_width = 40
+
+    table = Table(
+        box=box.SIMPLE,
+        show_header=True,
+        header_style="bold cyan",
+        title=f"Submissions per queue  (total: {total})",
+        title_style="bold",
+    )
+    table.add_column("Queue", style="dim", no_wrap=True)
+    table.add_column("Bar", min_width=bar_width)
+    table.add_column("Count", justify="right", style="bold green")
+    table.add_column("%", justify="right", style="cyan")
+
+    for _, name, count in results:
+        filled = int(count / max_count * bar_width) if max_count > 0 else 0
+        bar = "[green]" + "█" * filled + "[/green]"
+        pct = f"{count / total * 100:.1f}" if total > 0 else "0.0"
+        table.add_row(name, bar, str(count), pct)
+
+    console.print(table)

--- a/cnb_tools/commands/summarize_cli.py
+++ b/cnb_tools/commands/summarize_cli.py
@@ -1,0 +1,316 @@
+"""CLI command: summarize
+
+Summarize challenge by submissions and participants.
+
+Example:
+    $ cnb-tools summarize --help
+    $ cnb-tools summarize submissions syn12345678
+    $ cnb-tools summarize submissions syn12345678 --weekly
+    $ cnb-tools summarize participants syn12345678
+"""
+
+import sys
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime
+
+import typer
+from rich import box
+from rich.console import Console
+from rich.progress import Progress
+from rich.table import Table
+from synapseclient.models import UserProfile
+from typing_extensions import Annotated
+
+from cnb_tools.modules.challenge import get_challenge
+from cnb_tools.modules.client import UnknownSynapseID, get_synapse_client
+from cnb_tools.modules.queue import get_evaluations_by_project
+
+app = typer.Typer()
+
+# ---------------------------------------------------------------------------
+# Participant classification
+# ---------------------------------------------------------------------------
+
+_ACADEMIA_KEYWORDS = {
+    "university",
+    "université",
+    "universitat",
+    "universidad",
+    "universidade",
+    "college",
+    "institute",
+    "institution",
+    "school",
+    "hospital",
+    "clinic",
+    "academic",
+    "academia",
+    "research",
+    "laboratory",
+    "lab",
+    "student",
+    "faculty",
+    "department",
+    "dept",
+    "center",
+    "centre",
+}
+_INDUSTRY_KEYWORDS = {
+    "inc",
+    "corp",
+    "corporation",
+    "ltd",
+    "llc",
+    "gmbh",
+    "pharma",
+    "biotech",
+    "therapeutics",
+    "diagnostics",
+    "technologies",
+    "solutions",
+    "systems",
+    "software",
+    "consulting",
+    "ventures",
+}
+_GOVERNMENT_KEYWORDS = {
+    "government",
+    "federal",
+    "national",
+    "ministry",
+    "agency",
+    "bureau",
+    "nih",
+    "nci",
+    "fda",
+    "cdc",
+    "nasa",
+    "darpa",
+}
+_NONPROFIT_KEYWORDS = {
+    "foundation",
+    "nonprofit",
+    "non-profit",
+    "charity",
+    "association",
+    "society",
+    "alliance",
+}
+
+_CATEGORY_ORDER = [
+    "Academia",
+    "Industry / For-profit",
+    "Government",
+    "Non-profit",
+    "Other",
+    "Not specified",
+]
+_CATEGORY_COLORS = {
+    "Academia": "cyan",
+    "Industry / For-profit": "yellow",
+    "Government": "blue",
+    "Non-profit": "magenta",
+    "Other": "red",
+    "Not specified": "dim",
+}
+
+
+def _classify_org(company: str, industry: str) -> str:
+    text = (company + " " + industry).lower()
+    if not text.strip():
+        return "Not specified"
+    for kw in _ACADEMIA_KEYWORDS:
+        if kw in text:
+            return "Academia"
+    for kw in _GOVERNMENT_KEYWORDS:
+        if kw in text:
+            return "Government"
+    for kw in _NONPROFIT_KEYWORDS:
+        if kw in text:
+            return "Non-profit"
+    for kw in _INDUSTRY_KEYWORDS:
+        if kw in text:
+            return "Industry / For-profit"
+    return "Other"
+
+
+# ---------------------------------------------------------------------------
+# Submission trends helpers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_submission_dates(syn, evaluation_id: str) -> list[str]:
+    dates = []
+    for sub in syn.getSubmissions(evaluation_id):
+        created_on = sub.get("createdOn")
+        if created_on:
+            dt = datetime.fromisoformat(created_on.replace("Z", "+00:00"))
+            dates.append(dt.strftime("%Y-%m-%d"))
+    return dates
+
+
+def _to_week(date_str: str) -> str:
+    dt = datetime.strptime(date_str, "%Y-%m-%d")
+    return f"{dt.isocalendar()[0]}-W{dt.isocalendar()[1]:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+
+@app.command()
+def submissions(
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
+    weekly: Annotated[
+        bool,
+        typer.Option("--weekly", help="Group by ISO week instead of day"),
+    ] = False,
+):
+    """Show a histogram of submissions over time.
+
+    Fetches all submissions across every evaluation queue and prints a bar
+    chart grouped by day (default) or ISO week (--weekly).
+    """
+    syn = get_synapse_client()
+    console = Console()
+
+    try:
+        evaluations = get_evaluations_by_project(project_id)
+    except UnknownSynapseID as err:
+        sys.exit(err)
+
+    if not evaluations:
+        typer.echo(f"No evaluation queues found for {project_id}.")
+        return
+
+    console.print(
+        f"Found [bold]{len(evaluations)}[/bold] queue(s). Fetching submissions...\n"
+    )
+
+    all_dates: list[str] = []
+
+    def _fetch(ev) -> list[str]:
+        return _fetch_submission_dates(syn, ev.id)
+
+    with ThreadPoolExecutor(max_workers=min(8, len(evaluations))) as pool:
+        futures = {pool.submit(_fetch, ev): ev for ev in evaluations}
+        for future in as_completed(futures):
+            all_dates.extend(future.result())
+
+    if not all_dates:
+        typer.echo("No submissions found.")
+        return
+
+    if weekly:
+        counts: Counter = Counter(_to_week(d) for d in all_dates)
+        label = "week"
+    else:
+        counts = Counter(all_dates)
+        label = "day"
+
+    sorted_keys = sorted(counts.keys())
+    max_count = max(counts.values())
+    total = sum(counts.values())
+    bar_width = 40
+
+    table = Table(
+        box=box.SIMPLE,
+        show_header=True,
+        header_style="bold cyan",
+        title=f"Submissions per {label}  (total: {total})",
+        title_style="bold",
+    )
+    table.add_column(label.capitalize(), style="dim", no_wrap=True)
+    table.add_column("Bar", min_width=bar_width)
+    table.add_column("Count", justify="right", style="bold green")
+    table.add_column("%", justify="right", style="cyan")
+
+    for key in sorted_keys:
+        count = counts[key]
+        filled = int(count / max_count * bar_width) if max_count > 0 else 0
+        bar = "[green]" + "█" * filled + "[/green]"
+        pct = f"{count / total * 100:.1f}"
+        table.add_row(key, bar, str(count), pct)
+
+    console.print(table)
+
+
+@app.command()
+def participants(
+    project_id: Annotated[
+        str, typer.Argument(help="Synapse ID of the challenge project")
+    ],
+):
+    """Show a breakdown of participants by organization type.
+
+    Classifies each participant based on the company and industry fields in
+    their Synapse profile using keyword matching. Results are estimates.
+    """
+    syn = get_synapse_client()
+    console = Console()
+
+    try:
+        chal = get_challenge(project_id)
+    except UnknownSynapseID as err:
+        sys.exit(err)
+
+    team_id = chal["participantTeamId"]
+    console.print(
+        f"Project [bold]{project_id}[/bold] → participant team [bold]{team_id}[/bold]"
+    )
+
+    members = list(syn._GET_paginated(f"/teamMembers/{team_id}"))
+    user_ids = [m["member"]["ownerId"] for m in members]
+    console.print(
+        f"Found [bold]{len(user_ids)}[/bold] member(s). Fetching profiles...\n"
+    )
+
+    def _classify(uid: str) -> str:
+        profile = UserProfile.from_id(user_id=int(uid))
+        return _classify_org(
+            profile.company or "",
+            profile.industry or "",
+        )
+
+    counts: Counter = Counter()
+    with Progress(console=console, transient=True) as progress:
+        task = progress.add_task("Fetching profiles...", total=len(user_ids))
+        with ThreadPoolExecutor(max_workers=min(16, len(user_ids))) as pool:
+            futures = {pool.submit(_classify, uid): uid for uid in user_ids}
+            for future in as_completed(futures):
+                counts[future.result()] += 1
+                progress.advance(task)
+
+    total = sum(counts.values())
+    bar_width = 40
+    max_count = max(counts.values()) if counts else 1
+
+    table = Table(
+        box=box.SIMPLE,
+        show_header=True,
+        header_style="bold cyan",
+        title=f"Participant breakdown  (total: {total})",
+        title_style="bold",
+    )
+    table.add_column("Category", no_wrap=True)
+    table.add_column("Bar", min_width=bar_width)
+    table.add_column("Count", justify="right", style="bold green")
+    table.add_column("%", justify="right", style="cyan")
+
+    for category in _CATEGORY_ORDER:
+        count = counts.get(category, 0)
+        color = _CATEGORY_COLORS[category]
+        filled = int(count / max_count * bar_width) if count > 0 else 0
+        bar = f"[{color}]" + "█" * filled + f"[/{color}]"
+        pct = f"{count / total * 100:.1f}" if count > 0 else "0.0"
+        table.add_row(f"[{color}]{category}[/{color}]", bar, str(count), pct)
+
+    console.print(table)
+    console.print(
+        "[dim]Note: Categories are estimated using keyword matching on self-reported "
+        "company and industry fields. Results may not be accurate.[/dim]\n"
+    )

--- a/cnb_tools/commands/summarize_cli.py
+++ b/cnb_tools/commands/summarize_cli.py
@@ -28,10 +28,6 @@ from cnb_tools.modules.queue import get_evaluations_by_project
 
 app = typer.Typer()
 
-# ---------------------------------------------------------------------------
-# Participant classification
-# ---------------------------------------------------------------------------
-
 _ACADEMIA_KEYWORDS = {
     "university",
     "université",
@@ -135,11 +131,6 @@ def _classify_org(company: str, industry: str) -> str:
     return "Other"
 
 
-# ---------------------------------------------------------------------------
-# Submission trends helpers
-# ---------------------------------------------------------------------------
-
-
 def _fetch_submission_dates(syn, evaluation_id: str) -> list[str]:
     dates = []
     for sub in syn.getSubmissions(evaluation_id):
@@ -155,27 +146,22 @@ def _to_week(date_str: str) -> str:
     return f"{dt.isocalendar()[0]}-W{dt.isocalendar()[1]:02d}"
 
 
-# ---------------------------------------------------------------------------
-# Commands
-# ---------------------------------------------------------------------------
-
-
 @app.command()
 def submissions(
     project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
     weekly: Annotated[
         bool,
-        typer.Option("--weekly", help="Group by ISO week instead of day"),
+        typer.Option("--weekly", help="Summarize by week"),
     ] = False,
     ignore_empty: Annotated[
         bool,
         typer.Option("--ignore-empty", help="Hide rows with zero counts"),
     ] = False,
 ):
-    """Show a histogram of submissions over time.
+    """Summarize submissions over time.
 
     Fetches all submissions across every evaluation queue and prints a bar
-    chart grouped by day (default) or ISO week (--weekly).
+    chart grouped by day (default) or week (--weekly).
     """
     syn = get_synapse_client()
     console = Console()
@@ -237,7 +223,6 @@ def submissions(
         bar = "[green]" + "█" * filled + "[/green]"
         pct = f"{count / total * 100:.1f}"
         table.add_row(key, bar, str(count), pct)
-
     console.print(table)
 
 
@@ -249,10 +234,10 @@ def participants(
         typer.Option("--ignore-empty", help="Hide categories with zero participants"),
     ] = False,
 ):
-    """Show a breakdown of participants by organization type.
+    """Summarize a breakdown of participants by sector type.
 
     Classifies each participant based on the company and industry fields in
-    their Synapse profile using keyword matching. Results are estimates.
+    their Synapse profile using keyword matching. Results are estimates of sector type.
     """
     syn = get_synapse_client()
     console = Console()
@@ -310,7 +295,6 @@ def participants(
         bar = f"[{color}]" + "█" * filled + f"[/{color}]"
         pct = f"{count / total * 100:.1f}" if count > 0 else "0.0"
         table.add_row(f"[{color}]{category}[/{color}]", bar, str(count), pct)
-
     console.print(table)
     console.print(
         "[dim]Note: Categories are estimated using keyword matching on self-reported "
@@ -326,7 +310,7 @@ def queues(
         typer.Option("--ignore-empty", help="Hide queues with zero submissions"),
     ] = False,
 ):
-    """Show a breakdown of submissions per evaluation queue.
+    """Summarize a breakdown of submissions per evaluation queue.
 
     Fetches the submission count for each queue in parallel and prints a
     bar chart sorted by queue name.
@@ -379,5 +363,4 @@ def queues(
         bar = "[green]" + "█" * filled + "[/green]"
         pct = f"{count / total * 100:.1f}" if total > 0 else "0.0"
         table.add_row(name, bar, str(count), pct)
-
     console.print(table)

--- a/cnb_tools/commands/summarize_cli.py
+++ b/cnb_tools/commands/summarize_cli.py
@@ -162,9 +162,7 @@ def _to_week(date_str: str) -> str:
 
 @app.command()
 def submissions(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
     weekly: Annotated[
         bool,
         typer.Option("--weekly", help="Group by ISO week instead of day"),
@@ -187,9 +185,7 @@ def submissions(
         typer.echo(f"No evaluation queues found for {project_id}.")
         return
 
-    console.print(
-        f"Found [bold]{len(evaluations)}[/bold] queue(s). Fetching submissions...\n"
-    )
+    console.print(f"Found [bold]{len(evaluations)}[/bold] queue(s). Fetching submissions...\n")
 
     all_dates: list[str] = []
 
@@ -241,9 +237,7 @@ def submissions(
 
 @app.command()
 def participants(
-    project_id: Annotated[
-        str, typer.Argument(help="Synapse ID of the challenge project")
-    ],
+    project_id: Annotated[str, typer.Argument(help="Synapse ID of the challenge project")],
 ):
     """Show a breakdown of participants by organization type.
 
@@ -259,15 +253,11 @@ def participants(
         sys.exit(err)
 
     team_id = chal["participantTeamId"]
-    console.print(
-        f"Project [bold]{project_id}[/bold] → participant team [bold]{team_id}[/bold]"
-    )
+    console.print(f"Project [bold]{project_id}[/bold] → participant team [bold]{team_id}[/bold]")
 
     members = list(syn._GET_paginated(f"/teamMembers/{team_id}"))
     user_ids = [m["member"]["ownerId"] for m in members]
-    console.print(
-        f"Found [bold]{len(user_ids)}[/bold] member(s). Fetching profiles...\n"
-    )
+    console.print(f"Found [bold]{len(user_ids)}[/bold] member(s). Fetching profiles...\n")
 
     def _classify(uid: str) -> str:
         profile = UserProfile.from_id(user_id=int(uid))

--- a/cnb_tools/main_cli.py
+++ b/cnb_tools/main_cli.py
@@ -16,6 +16,7 @@ from cnb_tools.commands import (
     challenge_cli,
     queue_cli,
     submission_cli,
+    summarize_cli,
 )
 
 app = typer.Typer(rich_markup_mode="rich")
@@ -33,6 +34,11 @@ app.add_typer(
     submission_cli.app,
     name="submission",
     help=("Manage submissions."),
+)
+app.add_typer(
+    summarize_cli.app,
+    name="summarize",
+    help="Summarize challenge data (submissions, participants).",
 )
 
 

--- a/cnb_tools/modules/new_challenge.py
+++ b/cnb_tools/modules/new_challenge.py
@@ -108,9 +108,7 @@ def _create_data_folders(
     public_folder = Folder(name="Data", parent_id=project_id)
     public_folder = public_folder.store()
     logger.info(f"Folder created: {public_folder.name} ({public_folder.id})")
-    permissions.set_entity_permissions(
-        public_folder.id, organizer_team_id, permission_level="edit"
-    )
+    permissions.set_entity_permissions(public_folder.id, organizer_team_id, permission_level="edit")
     permissions.set_entity_permissions(
         public_folder.id, participant_team_id, permission_level="download"
     )
@@ -210,9 +208,7 @@ def main(
             description=f"Task {i + 1} Submission",
             project_id=project_live.id,
         )
-        permissions.set_evaluation_permissions(
-            ev.id, SAGE_CNB_TEAM, permission_level="admin"
-        )
+        permissions.set_evaluation_permissions(ev.id, SAGE_CNB_TEAM, permission_level="admin")
 
     _create_data_folders(
         project_live.id,
@@ -283,6 +279,4 @@ def close_challenge(project_id: str) -> None:
 
     # 3. Lock the participant team
     participant.lock_team(participant_team_id)
-    logger.info(
-        f"Participant team {participant_team_id} locked (no public join or requests)"
-    )
+    logger.info(f"Participant team {participant_team_id} locked (no public join or requests)")

--- a/cnb_tools/modules/new_challenge.py
+++ b/cnb_tools/modules/new_challenge.py
@@ -108,7 +108,9 @@ def _create_data_folders(
     public_folder = Folder(name="Data", parent_id=project_id)
     public_folder = public_folder.store()
     logger.info(f"Folder created: {public_folder.name} ({public_folder.id})")
-    permissions.set_entity_permissions(public_folder.id, organizer_team_id, permission_level="edit")
+    permissions.set_entity_permissions(
+        public_folder.id, organizer_team_id, permission_level="edit"
+    )
     permissions.set_entity_permissions(
         public_folder.id, participant_team_id, permission_level="download"
     )
@@ -208,7 +210,9 @@ def main(
             description=f"Task {i + 1} Submission",
             project_id=project_live.id,
         )
-        permissions.set_evaluation_permissions(ev.id, SAGE_CNB_TEAM, permission_level="admin")
+        permissions.set_evaluation_permissions(
+            ev.id, SAGE_CNB_TEAM, permission_level="admin"
+        )
 
     _create_data_folders(
         project_live.id,
@@ -270,7 +274,7 @@ def close_challenge(project_id: str) -> None:
     logger.info(f"Project {project_id} Status set to 'Closed'")
 
     # 2. Downgrade participant team permissions on every queue
-    eval_ids = queue_module.get_evaluation_ids_by_project(project_id)
+    eval_ids = [ev.id for ev in queue_module.get_evaluations_by_project(project_id)]
     for eval_id in eval_ids:
         permissions.set_evaluation_permissions(
             eval_id, participant_team_id, permission_level="view"
@@ -279,4 +283,6 @@ def close_challenge(project_id: str) -> None:
 
     # 3. Lock the participant team
     participant.lock_team(participant_team_id)
-    logger.info(f"Participant team {participant_team_id} locked (no public join or requests)")
+    logger.info(
+        f"Participant team {participant_team_id} locked (no public join or requests)"
+    )

--- a/cnb_tools/modules/queue.py
+++ b/cnb_tools/modules/queue.py
@@ -37,26 +37,13 @@ def get_evaluation(evaluation_id: int) -> Evaluation:
         ) from err
 
 
-def get_evaluation_ids_by_project(project_id: str) -> list[str]:
-    """Return the IDs of all evaluation queues linked to a Synapse project.
-
-    Tip: Example Use Case
-      List every queue associated with a challenge project before bulk-
-      updating permissions or closing the challenge.
-
-    Args:
-      project_id: Synapse ID of the challenge project.
-
-    Returns:
-      List of evaluation queue ID strings.
-    """
-    get_synapse_client()  # ensure authentication
-    evaluations = Evaluation.get_evaluations_by_project(project_id=project_id)
-    return [ev.id for ev in evaluations if ev.id]
-
-
 def get_evaluations_by_project(project_id: str) -> list[Evaluation]:
     """Return all evaluation queues linked to a Synapse project.
+
+    Note: This is a wrapper around ``Evaluation.get_evaluations_by_project()``
+    from the synapseclient. The client defaults to ``limit=10``, which would
+    silently truncate challenges with more than 10 queues. This wrapper passes
+    ``limit=100``, the API maximum.
 
     Tip: Example Use Case
       Inspect all queues for a challenge project, e.g. to display their
@@ -71,9 +58,11 @@ def get_evaluations_by_project(project_id: str) -> list[Evaluation]:
     Raises:
       UnknownSynapseID: If the project ID is invalid.
     """
-    get_synapse_client()  # ensure authentication
+    get_synapse_client()
     try:
-        return list(Evaluation.get_evaluations_by_project(project_id=project_id))
+        # TODO: If a project ever has more than 100 queues, replace this with
+        # a pagination loop (limit=100, offset incremented until page < 100).
+        return Evaluation.get_evaluations_by_project(project_id=project_id, limit=100)
     except SynapseHTTPError as err:
         raise UnknownSynapseID(
             f"⛔ {err.response.json().get('reason')}. Check the ID and try again."

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -402,3 +402,84 @@ Options:
 Name | Type | Description | Default
 --|--|--|--
 `--skip-errors` | boolean | Continue update even if unknown ID error is encountered | False
+
+---
+
+## Command: `summarize`
+
+Summarize challenge activity for a post-challenge landscape. Results will return
+as bar charts, counts, and percentages.
+
+By default, all results are returned, but empty results can be ignored with `--ignore-empty`.
+
+### `submissions`
+
+Show a breakdown of submissions over time. Fetches all submissions across every
+evaluation queue and groups them by day (default) or week (`--weekly`).
+
+```bash
+cnb-tools summarize submissions PROJECT_ID [--weekly] [--ignore-empty]
+```
+
+Replace the following:
+
+- _`PROJECT_ID`_ - Synapse ID of the challenge project
+
+Options:
+
+Name | Type | Description | Default
+--|--|--|--
+`--weekly` | boolean | Group by ISO week instead of day | False
+`--ignore-empty` | boolean | Hide rows with zero counts | False
+
+### `participants`
+
+Show a breakdown of participants by sector type (academia, government, non-profit, for-profit,
+other).
+
+!!!note
+    Categories are estimated using keyword matching on self-reported profile
+    fields. Results may not be accurate.
+
+```bash
+cnb-tools summarize participants PROJECT_ID [--ignore-empty]
+```
+
+Replace the following:
+
+- _`PROJECT_ID`_ - Synapse ID of the challenge project
+
+Options:
+
+Name | Type | Description | Default
+--|--|--|--
+`--ignore-empty` | boolean | Hide categories with zero participants | False
+
+Categories (in display order):
+
+| Category | Description |
+|---|---|
+| Academia | Universities, hospitals, institutes, research centers |
+| Industry / For-profit | Companies, biotech, pharma, consulting |
+| Government | Federal agencies (NIH, FDA, CDC, etc.) |
+| Non-profit | Foundations, societies, associations |
+| Other | Profile fields filled but no keyword matched |
+| Not specified | Both company and industry fields are blank |
+
+### `queues`
+
+Show a breakdown of submissions per evaluation queue.
+
+```bash
+cnb-tools summarize queues PROJECT_ID [--ignore-empty]
+```
+
+Replace the following:
+
+- _`PROJECT_ID`_ - Synapse ID of the challenge project
+
+Options:
+
+Name | Type | Description | Default
+--|--|--|--
+`--ignore-empty` | boolean | Hide queues with zero submissions | False

--- a/docs/user-guide/cheat-sheet.md
+++ b/docs/user-guide/cheat-sheet.md
@@ -27,10 +27,9 @@ get_registered_teams(challenge_id)         # list all registered teams
 ### Queue
 
 ```python
-from cnb_tools import get_evaluation, get_evaluation_ids_by_project, get_evaluations_by_project, create_evaluation, create_evaluation_round
+from cnb_tools import get_evaluation, get_evaluations_by_project, create_evaluation, create_evaluation_round
 
 get_evaluation(evaluation_id)                        # get queue details
-get_evaluation_ids_by_project(project_id)            # list all queue IDs for a project
 get_evaluations_by_project(project_id)               # list all queue objects for a project
 create_evaluation(name, description, project_id)     # create a new queue
 create_evaluation_round(evaluation_id, ...)          # add a submission round

--- a/docs/user-guide/introduction.md
+++ b/docs/user-guide/introduction.md
@@ -108,6 +108,30 @@ participant team, and update the project status:
 cnb-tools challenge close syn12345
 ```
 
+In addition to closing, you can also observe the challenge activity over time:
+
+**Visualize submission trends over time:**
+
+```bash
+# By day (default)
+cnb-tools summarize submissions syn12345
+
+# Grouped by ISO week
+cnb-tools summarize submissions syn12345 --weekly
+```
+
+**See how many submissions each queue received:**
+
+```bash
+cnb-tools summarize queues syn12345
+```
+
+**See where participants are coming from (by org type):**
+
+```bash
+cnb-tools summarize participants syn12345
+```
+
 ---
 
 ## Next Steps

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -14,7 +14,9 @@ class TestGetEvaluation:
 
     @patch("cnb_tools.modules.queue.Evaluation")
     @patch("cnb_tools.modules.queue.get_synapse_client")
-    def test_get_evaluation_success(self, mock_get_client, MockEvaluation, mock_evaluation):
+    def test_get_evaluation_success(
+        self, mock_get_client, MockEvaluation, mock_evaluation
+    ):
         """Test successfully getting an evaluation"""
         MockEvaluation.return_value.get.return_value = mock_evaluation
 
@@ -30,7 +32,9 @@ class TestGetEvaluation:
         """Test error handling for invalid evaluation ID"""
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Evaluation not found"}
-        MockEvaluation.return_value.get.side_effect = SynapseHTTPError(response=mock_response)
+        MockEvaluation.return_value.get.side_effect = SynapseHTTPError(
+            response=mock_response
+        )
 
         with pytest.raises(UnknownSynapseID) as exc_info:
             queue.get_evaluation(99999)
@@ -43,13 +47,17 @@ class TestGetEvaluationsByProject:
 
     @patch("cnb_tools.modules.queue.Evaluation")
     @patch("cnb_tools.modules.queue.get_synapse_client")
-    def test_returns_list_of_evaluations(self, mock_get_client, MockEvaluation, mock_evaluation):
+    def test_returns_list_of_evaluations(
+        self, mock_get_client, MockEvaluation, mock_evaluation
+    ):
         """Test successfully listing evaluations for a project"""
         MockEvaluation.get_evaluations_by_project.return_value = [mock_evaluation]
 
         result = queue.get_evaluations_by_project("syn12345")
 
-        MockEvaluation.get_evaluations_by_project.assert_called_once_with(project_id="syn12345")
+        MockEvaluation.get_evaluations_by_project.assert_called_once_with(
+            project_id="syn12345", limit=100
+        )
         assert result == [mock_evaluation]
 
     @patch("cnb_tools.modules.queue.Evaluation")
@@ -64,7 +72,9 @@ class TestGetEvaluationsByProject:
 
     @patch("cnb_tools.modules.queue.Evaluation")
     @patch("cnb_tools.modules.queue.get_synapse_client")
-    def test_raises_unknown_synapse_id_on_invalid_project(self, mock_get_client, MockEvaluation):
+    def test_raises_unknown_synapse_id_on_invalid_project(
+        self, mock_get_client, MockEvaluation
+    ):
         """Test error handling for invalid project ID"""
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Entity not found"}

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -14,9 +14,7 @@ class TestGetEvaluation:
 
     @patch("cnb_tools.modules.queue.Evaluation")
     @patch("cnb_tools.modules.queue.get_synapse_client")
-    def test_get_evaluation_success(
-        self, mock_get_client, MockEvaluation, mock_evaluation
-    ):
+    def test_get_evaluation_success(self, mock_get_client, MockEvaluation, mock_evaluation):
         """Test successfully getting an evaluation"""
         MockEvaluation.return_value.get.return_value = mock_evaluation
 
@@ -32,9 +30,7 @@ class TestGetEvaluation:
         """Test error handling for invalid evaluation ID"""
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Evaluation not found"}
-        MockEvaluation.return_value.get.side_effect = SynapseHTTPError(
-            response=mock_response
-        )
+        MockEvaluation.return_value.get.side_effect = SynapseHTTPError(response=mock_response)
 
         with pytest.raises(UnknownSynapseID) as exc_info:
             queue.get_evaluation(99999)
@@ -47,9 +43,7 @@ class TestGetEvaluationsByProject:
 
     @patch("cnb_tools.modules.queue.Evaluation")
     @patch("cnb_tools.modules.queue.get_synapse_client")
-    def test_returns_list_of_evaluations(
-        self, mock_get_client, MockEvaluation, mock_evaluation
-    ):
+    def test_returns_list_of_evaluations(self, mock_get_client, MockEvaluation, mock_evaluation):
         """Test successfully listing evaluations for a project"""
         MockEvaluation.get_evaluations_by_project.return_value = [mock_evaluation]
 
@@ -72,9 +66,7 @@ class TestGetEvaluationsByProject:
 
     @patch("cnb_tools.modules.queue.Evaluation")
     @patch("cnb_tools.modules.queue.get_synapse_client")
-    def test_raises_unknown_synapse_id_on_invalid_project(
-        self, mock_get_client, MockEvaluation
-    ):
+    def test_raises_unknown_synapse_id_on_invalid_project(self, mock_get_client, MockEvaluation):
         """Test error handling for invalid project ID"""
         mock_response = Mock()
         mock_response.json.return_value = {"reason": "Entity not found"}


### PR DESCRIPTION
## User Story

As a challenge organizer, I want to summarize a challenge after it's concluded so that I can more easily report on participant demographics and submissions trends.

## Changelog
- Add new CLI command group called `summarize` with two sub-commands:
   - `submissions` - breakdown of submissions received daily (or weekly)
   - `participants` - breakdown of registered participants, categorized by sector
   - `queues` - breakdown of submission per queue
- General performance and lint updates

> [!NOTE]
> Participant breakdowns may not be fully comprehensive, as sector categorization relies on users completing their Synapse profiles and our keyword matching rules

## Preview

Example run using the BraTS 2026 Challenge

```
$ cnb-tools summarize submissions syn74274097
Found 15 queue(s). Fetching submissions...

                  Submissions per day  (total: 2937)                   
                                                                       
  Day          Bar                                        Count     %  
 ───────────────────────────────────────────────────────────────────── 
  2026-06-01   ██                                             5   0.2  
  2026-06-02   ████                                          11   0.4  
  2026-06-03   █                                              4   0.1  
  2026-06-04   ███████████                                   28   1.0  
  2026-06-05   ████████████                                  30   1.0  
  2026-06-06   ██████████                                    25   0.9  
  2026-06-07   █████████                                     24   0.8  
  2026-06-08   ████████████████                              41   1.4  
  2026-06-09   ████████████                                  30   1.0  
  2026-06-10   █████████████                                 34   1.2  
  2026-06-11   ████████████████████                          51   1.7  
  2026-06-12   █████████████████████                         54   1.8  
  2026-06-13   ████████████████████████                      60   2.0  
  2026-06-14   █████████████████                             43   1.5  
  2026-06-15   █████████████████████                         54   1.8  
  2026-06-16   ██████████████████████                        57   1.9  
  2026-06-17   ████████████████████                          51   1.7  
  2026-06-18   ███████████████                               39   1.3  
  2026-06-19   ███████████████████                           49   1.7  
  2026-06-20   ████████████████████████                      60   2.0  
  2026-06-21   ██████████████████                            47   1.6  
  2026-06-22   █████████████████████                         54   1.8  
  2026-06-23   █████████████████████                         54   1.8  
  2026-06-24   ████████████████████████                      60   2.0  
  2026-06-25   ██████████████████                            46   1.6  
  2026-06-26   ██████████████                                37   1.3  
  2026-06-27   ████████████████████                          50   1.7  
  2026-06-28   ████████████████████                          51   1.7  
  2026-06-29   ███████████████████                           48   1.6  
  2026-06-30   ██████████████████                            46   1.6  
  2026-07-01   █████████████████                             44   1.5  
  2026-07-02   ████████████████████                          51   1.7  
  2026-07-03   ██████████████                                35   1.2  
  2026-07-04   ██████████████████████                        57   1.9  
  2026-07-05   ██████████████████████                        56   1.9  
  2026-07-06   ████████████████████                          51   1.7  
  2026-07-07   ████████████████████████████                  72   2.5  
  2026-07-08   ███████████████████████████                   69   2.3  
  2026-07-09   ███████████████████████████████               79   2.7  
  2026-07-10   ██████████████████████████                    67   2.3  
  2026-07-11   ████████████████████████                      62   2.1  
  2026-07-12   ███████████████████████████                   69   2.3  
  2026-07-13   █████████████████████████████████████         93   3.2  
  2026-07-14   ███████████████████████████████████           88   3.0  
  2026-07-15   ████████████████████████████████████████     100   3.4  
  2026-07-16   ███████████████████████████████               79   2.7  
  2026-07-17   ████████████████████████████████              82   2.8  
  2026-07-18   █████████████████████████████                 74   2.5  
  2026-07-19   ████████████████████████████                  71   2.4  
  2026-07-20   ████████████████████████████████              81   2.8  
  2026-07-21   ██████████████████████████████████            86   2.9  
  2026-07-22   ██████████████████████████████████            87   3.0  
  2026-07-23   ████████████████████████████████████          91   3.1  
  2026-07-24   ████████████████████                          50   1.7 
```

```
$ cnb-tools summarize participants syn74274097
Project syn74274097 → participant team 3584866
Found 635 member(s). Fetching profiles...

                        Participant breakdown  (total: 635)                        
                                                                                   
  Category                Bar                                        Count      %  
 ───────────────────────────────────────────────────────────────────────────────── 
  Academia                █████████                                    117   18.4  
  Industry / For-profit                                                  2    0.3  
  Government                                                             1    0.2  
  Non-profit                                                             0    0.0  
  Other                   ██                                            32    5.0  
  Not specified           ████████████████████████████████████████     483   76.1  
                                                                                   
Note: Categories are estimated using keyword matching on self-reported company and industry fields.
Results may not be accurate.
```

```
$ cnb-tools summarize queues syn74274097
                                 Submissions per queue  (total: 2937)                                  
                                                                                                       
  Queue                                       Bar                                        Count      %  
 ───────────────────────────────────────────────────────────────────────────────────────────────────── 
  Task 1: Brain Metastases - Docker                                                          8    0.3  
  Task 1: Brain Metastases - Docker (EARLY)                                                  0    0.0  
  Task 1: Brain Metastases - Predictions      ████████████████████████████████████████     914   31.1  
  Task 2: Pediatric Tumors - Docker                                                          7    0.2  
  Task 2: Pediatric Tumors - Docker (EARLY)                                                  2    0.1  
  Task 2: Pediatric Tumors - Predictions      █████████████████████                        486   16.5  
  Task 3: Generalizability - Docker                                                         10    0.3  
  Task 3: Generalizability - Docker (EARLY)                                                  3    0.1  
  Task 3: Generalizability - Predictions      █████████████████████████████                671   22.8  
  Task 4: Inpainting - Docker                                                                9    0.3  
  Task 4: Inpainting - Docker (EARLY)                                                        1    0.0  
  Task 4: Inpainting - Predictions            ██████████████████                           429   14.6  
  Task 5: Pathology - Docker                                                                 0    0.0  
  Task 5: Pathology - Docker (EARLY)                                                         0    0.0  
  Task 5: Pathology - Predictions             █████████████████                            397   13.5
```